### PR TITLE
feat: basic wallet quests

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import { TonConnectButton, TonConnectUIProvider } from '@tonconnect/ui-react';
+import WalletInput from './components/WalletInput';
 import Quests from './pages/Quests';
 import Profile from './pages/Profile';
 import Subscription from './pages/Subscription';
@@ -27,6 +28,7 @@ function App() {
               <Link to="/isles">🌊Isles</Link>
             </nav>
             <TonConnectButton className="ton-connect" />
+            <WalletInput />
           </header>
 
           <Routes>

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -1,0 +1,19 @@
+# Launch Notes
+
+## Environment
+
+```
+REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
+```
+
+## Vercel
+
+Add the domains:
+- 7goldencowries.com
+- www.7goldencowries.com
+
+## Manual Test Steps
+
+1. Set wallet to `UQTestWallet123` in the header input.
+2. Claim "Join our Telegram" → XP +40, then re-claim → Already claimed.
+3. Refresh page → XP persists.

--- a/README.md
+++ b/README.md
@@ -1,70 +1,19 @@
-# Getting Started with Create React App
+# 7GoldenCowries Frontend
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Minimal React app for the 7GoldenCowries launch.
 
-## Available Scripts
+## Configuration
 
-In the project directory, you can run:
+Set the backend URL before starting the app:
 
-### `npm start`
+```
+REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
+```
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+## Scripts
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+- `npm start` – run development server
+- `npm test` – run tests
+- `npm run build` – production build
 
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+See [LAUNCH.md](LAUNCH.md) for deployment notes and manual test steps.

--- a/src/components/ProfileWidget.js
+++ b/src/components/ProfileWidget.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { getMe, getProgression } from '../lib/api';
+
+export default function ProfileWidget() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [progress, setProgress] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const wallet = localStorage.getItem('wallet') || '';
+        let me = await getMe(wallet);
+        let prog = me?.progress;
+        if (!prog) {
+          const p = await getProgression();
+          prog = p;
+        }
+        setProgress({
+          levelName: prog.levelName || prog.level || '',
+          xp: prog.xp ?? prog.currentXP ?? me?.xp ?? 0,
+          next: prog.next || prog.nextThreshold || prog.nextXP || 0,
+        });
+      } catch (e) {
+        setError(e.message || 'Failed to load');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) return <div>Loading profile...</div>;
+  if (error) return <div>Error: {error}</div>;
+  if (!progress) return null;
+  const pct = progress.next ? Math.min(100, (progress.xp / progress.next) * 100) : 0;
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div>
+        Level {progress.levelName} — {progress.xp} / {progress.next}
+      </div>
+      <div style={{ background: '#eee', height: 8, borderRadius: 4 }}>
+        <div
+          style={{
+            width: `${pct}%`,
+            background: '#4caf50',
+            height: '100%',
+            borderRadius: 4,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function Toast({ message }) {
+  if (!message) return null;
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 20,
+        right: 20,
+        background: '#333',
+        color: '#fff',
+        padding: '8px 12px',
+        borderRadius: 4,
+      }}
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/components/WalletInput.js
+++ b/src/components/WalletInput.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+export default function WalletInput() {
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('wallet') || '';
+    setValue(saved);
+  }, []);
+
+  const onChange = (e) => setValue(e.target.value);
+  const onBlur = () => {
+    localStorage.setItem('wallet', value.trim());
+  };
+
+  return (
+    <input
+      type="text"
+      placeholder="wallet"
+      value={value}
+      onChange={onChange}
+      onBlur={onBlur}
+      style={{ width: 160, marginLeft: 8 }}
+    />
+  );
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,27 @@
+export const API_BASE = process.env.REACT_APP_API_URL || "";
+
+async function apiFetch(path, { method = 'GET', body, wallet } = {}) {
+  const headers = {};
+  if (body) headers['Content-Type'] = 'application/json';
+  const w = wallet || (typeof localStorage !== 'undefined' ? localStorage.getItem('wallet') : '');
+  if (w) headers['x-wallet'] = w;
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers,
+    credentials: 'include',
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let data = null;
+  try { data = await res.json(); } catch {}
+  if (!res.ok) {
+    const msg = data?.error || data?.message || res.statusText || 'Request failed';
+    throw new Error(msg);
+  }
+  return data;
+}
+
+export const getProgression = () => apiFetch('/api/meta/progression');
+export const getMe = (wallet) => apiFetch('/api/users/me', { wallet });
+export const getQuests = (wallet) => apiFetch('/api/quests', { wallet });
+export const claimQuest = (wallet, questId) =>
+  apiFetch('/api/quests/claim', { method: 'POST', wallet, body: { questId } });

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -1,481 +1,75 @@
-// src/pages/Quests.js
-import React, { useEffect, useMemo, useState } from "react";
-import confetti from "canvas-confetti";
-import XPModal from "../components/XPModal";
-import XPBar from "../components/XPBar";
-import "../components/XPBar.css";
-import "./Quests.css";
-import "../App.css";
-
-import { playClick, playXP } from "../utils/sounds";
-import { useTonAddress, useTonConnectUI } from "@tonconnect/ui-react";
-
-// API helpers (session-aware)
-import { getQuests, getMe } from "../utils/api";
-
-// NEW: secure quest utilities
-import { startLinkQuest, finishLinkQuest } from "../utils/quests";
-import { verifyTelegramJoin, verifyDiscordJoin } from "../utils/socialQuests";
-
-const QUEST_TABS = ["all", "daily", "social", "partner", "insider", "onchain"];
-
-// Helpers to detect social requirements from your legacy schema
-const isTelegramReq = (req = "") =>
-  ["tg_channel_member", "tg_group_member", "join_telegram", "join_telegram_channel", "join_telegram_group"].includes(
-    String(req).toLowerCase()
-  );
-const isDiscordReq = (req = "") =>
-  ["discord_member", "join_discord"].includes(String(req).toLowerCase());
+import React, { useEffect, useState } from 'react';
+import { getQuests, claimQuest, getMe } from '../lib/api';
+import Toast from '../components/Toast';
+import ProfileWidget from '../components/ProfileWidget';
 
 export default function Quests() {
   const [quests, setQuests] = useState([]);
-  const [completed, setCompleted] = useState([]); // quest IDs
-  const [xp, setXp] = useState(0);
-  const [tier, setTier] = useState("Free");
-  const [level, setLevel] = useState({
-    name: "Shellborn",
-    symbol: "🐚",
-    progress: 0,
-    nextXP: 10000,
-  });
-  const [wallet, setWallet] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [claiming, setClaiming] = useState({});
+  const [toast, setToast] = useState('');
 
-  const [activeTab, setActiveTab] = useState("all");
-  const [showLevelModal, setShowLevelModal] = useState(false);
-  const [unlocked, setUnlocked] = useState(null);
-  const [xpModalOpen, setXPModalOpen] = useState(false);
-  const [recentXP, setRecentXP] = useState(0);
-
-  // NEW: per-quest countdown and claiming state
-  const [timers, setTimers] = useState({}); // { [key]: secondsLeft }
-  const [claiming, setClaiming] = useState({}); // { [key]: boolean }
-  const [verifying, setVerifying] = useState(false); // for Telegram/Discord batch verify
-
-  // TonConnect
-  const tonAddress = useTonAddress();
-  const [tonUI] = useTonConnectUI();
-
-  // Persist any Ton wallet we learn about (helps other pages)
   useEffect(() => {
-    if (tonAddress && tonAddress.length > 0) {
-      setWallet(tonAddress);
-      localStorage.setItem("wallet", tonAddress);
-      localStorage.setItem("ton_wallet", tonAddress);
-      localStorage.setItem("walletAddress", tonAddress);
-    } else {
-      const saved =
-        localStorage.getItem("wallet") ||
-        localStorage.getItem("ton_wallet") ||
-        localStorage.getItem("walletAddress");
-      if (saved) setWallet(saved);
-    }
-  }, [tonAddress]);
-
-  // Initial load: session profile + quests
-  useEffect(() => {
-    (async () => {
+    async function load() {
       try {
-        // Profile via session cookie
-        const me = await getMe();
-        if (me?.authed) {
-          const p = me.profile || {};
-          setWallet((w) => w || p.wallet || null);
-          setXp(p.xp ?? 0);
-          setTier(p.tier || p.subscriptionTier || "Free");
-          setLevel({
-            name: p.levelName || p.level || "Shellborn",
-            symbol: p.levelSymbol || "🐚",
-            progress: p.levelProgress ?? 0,
-            nextXP: p.nextXP ?? 10000,
-          });
-          const done = Array.isArray(me.history)
-            ? me.history.map((h) => Number(h.id)).filter((n) => !Number.isNaN(n))
-            : [];
-          setCompleted(done);
-        }
-
-        // Quests list (supports multiple shapes)
-        const q = await getQuests();
-        const list = Array.isArray(q) ? q : Array.isArray(q?.quests) ? q.quests : [];
-        const normalized = list.map((quest) => ({
-          id: Number(quest.id),
-          code: quest.code || String(quest.id),
-          title: quest.title,
-          type: String(quest.type || "daily").toLowerCase(),
-          url: quest.url || "",
-          xp: quest.xp ?? 0,
-          requirement: String(quest.requirement || "").toLowerCase(),
-          active: quest.active !== 0, // default to active
-          completed: !!quest.completed,
-        }));
-        setQuests(normalized);
-      } catch (err) {
-        console.error("Failed to load quests/profile", err);
-        setQuests([]);
+        const wallet = localStorage.getItem('wallet') || '';
+        const q = await getQuests(wallet);
+        setQuests(q.quests || q || []);
+      } catch (e) {
+        setError(e.message || 'Failed to load quests');
+      } finally {
+        setLoading(false);
       }
-    })();
+    }
+    load();
   }, []);
 
-  // Derived list per tab
-  const shownQuests = useMemo(() => {
-    if (activeTab === "all") return quests;
-    return quests.filter((q) => (q.type || "").toLowerCase() === activeTab);
-  }, [quests, activeTab]);
-
-  // Tick all active countdowns
-  useEffect(() => {
-    const hasAny = Object.values(timers).some((v) => v > 0);
-    if (!hasAny) return;
-    const t = setInterval(() => {
-      setTimers((prev) => {
-        const next = { ...prev };
-        for (const k of Object.keys(next)) {
-          if (next[k] > 0) next[k] = next[k] - 1;
-        }
-        return next;
-      });
-    }, 1000);
-    return () => clearInterval(t);
-  }, [timers]);
-
-  // Utility to refresh profile (after awards)
-  const refreshProfile = async () => {
+  const handleClaim = async (id) => {
+    const wallet = localStorage.getItem('wallet') || '';
+    setClaiming((c) => ({ ...c, [id]: true }));
     try {
-      const me = await getMe();
-      if (!me?.authed) return;
-      const p = me.profile || {};
-      setXp(p.xp ?? 0);
-      setTier(p.tier || p.subscriptionTier || "Free");
-      const prevName = level?.name || "Shellborn";
-      const newName = p.levelName || p.level || prevName;
-      const newSymbol = p.levelSymbol || "🐚";
-      setLevel({
-        name: newName,
-        symbol: newSymbol,
-        progress: p.levelProgress ?? 0,
-        nextXP: p.nextXP ?? 10000,
-      });
-      // Level-up detection
-      if (newName && newName !== prevName) {
-        setUnlocked({ name: newName, symbol: newSymbol || "🐚" });
-        setShowLevelModal(true);
-      }
-    } catch (e) {
-      console.error("Profile refresh failed", e);
-    }
-  };
-
-  // ========= Secure flows =========
-
-  // 1) Start a link quest (opens /r/:nonce and starts a countdown)
-  const handleVisit = async (q) => {
-    try {
-      playClick();
-      const key = q.code || String(q.id);
-      const { redirectUrl, minSeconds, status } = await startLinkQuest(key);
-      if (status === "already_completed") {
-        // Mark completed locally
-        setCompleted((prev) => (prev.includes(q.id) ? prev : [...prev, q.id]));
-        setQuests((prev) => prev.map((it) => (it.id === q.id ? { ...it, completed: true } : it)));
-        return;
-      }
-      if (redirectUrl) {
-        // Start timer
-        setTimers((m) => ({ ...m, [key]: Number(minSeconds || 7) }));
-      }
-    } catch (e) {
-      console.error("startLinkQuest failed", e);
-      alert("Could not open quest link. Please try again.");
-    }
-  };
-
-  // 2) Claim a link quest (after the timer expires)
-  const handleClaim = async (q) => {
-    const key = q.code || String(q.id);
-    setClaiming((m) => ({ ...m, [key]: true }));
-    try {
-      const { status, xp: gained, error } = await finishLinkQuest(key);
-      if (error) {
-        alert(error);
+      const res = await claimQuest(wallet, id);
+      if (res?.alreadyClaimed) {
+        setToast('Already claimed');
       } else {
-        if (status === "completed") {
-          // XP modal + sound
-          setRecentXP(Number(gained || q.xp || 0));
-          setXPModalOpen(true);
-          playXP();
-          // confetti
-          confetti({ particleCount: 120, spread: 80, origin: { y: 0.6 } });
-          // mark completed
-          setCompleted((prev) => (prev.includes(q.id) ? prev : [...prev, q.id]));
-          setQuests((prev) => prev.map((it) => (it.id === q.id ? { ...it, completed: true } : it)));
-          // refresh profile
-          await refreshProfile();
-        } else if (status === "already_completed") {
-          setCompleted((prev) => (prev.includes(q.id) ? prev : [...prev, q.id]));
-          setQuests((prev) => prev.map((it) => (it.id === q.id ? { ...it, completed: true } : it)));
-        } else {
-          // e.g., Too fast
-          alert(status || "Unable to claim yet.");
-        }
+        setToast('Quest claimed');
+        await getMe(wallet);
       }
     } catch (e) {
-      console.error("finishLinkQuest failed", e);
-      alert("Could not claim. Please try again.");
+      setToast(e.message || 'Failed to claim');
     } finally {
-      setClaiming((m) => ({ ...m, [key]: false }));
-      // clear timer
-      setTimers((m) => {
-        const copy = { ...m };
-        delete copy[key];
-        return copy;
-      });
+      setClaiming((c) => ({ ...c, [id]: false }));
+      setTimeout(() => setToast(''), 3000);
     }
   };
 
-  // 3) Telegram verify (all/group/channel)
-  const handleVerifyTelegram = async (target /* 'group'|'channel'|undefined */) => {
-    try {
-      playClick();
-      setVerifying(true);
-      const { ok, results, error } = await verifyTelegramJoin(target);
-      if (error) {
-        alert(error);
-      } else if (ok) {
-        const earned = (results || []).filter((r) => r.status === "completed");
-        if (earned.length) {
-          const total = earned.reduce((s, r) => s + (r.xp || 0), 0);
-          setRecentXP(total);
-          setXPModalOpen(true);
-          playXP();
-          confetti({ particleCount: 100, spread: 70, origin: { y: 0.7 } });
-          await refreshProfile();
-        } else {
-          const notYet = (results || []).find((r) => r.status === "not_member");
-          if (notYet) alert(`Join the Telegram ${notYet.target} first, then verify again.`);
-          else alert("Nothing to verify right now.");
-        }
-      } else {
-        alert("Telegram verify failed.");
-      }
-    } catch (e) {
-      console.error("verifyTelegramJoin failed", e);
-      alert("Telegram verify failed. Try again.");
-    } finally {
-      setVerifying(false);
-    }
-  };
-
-  // 4) Discord verify
-  const handleVerifyDiscord = async () => {
-    try {
-      playClick();
-      setVerifying(true);
-      const { status, xp: gained, error } = await verifyDiscordJoin();
-      if (error) {
-        alert(error);
-      } else if (status === "completed") {
-        setRecentXP(Number(gained || 0));
-        setXPModalOpen(true);
-        playXP();
-        confetti({ particleCount: 100, spread: 70, origin: { y: 0.7 } });
-        await refreshProfile();
-      } else if (status === "already_completed") {
-        alert("Discord quest already completed ✅");
-      } else {
-        alert(status || "Nothing to verify.");
-      }
-    } catch (e) {
-      console.error("verifyDiscordJoin failed", e);
-      alert("Discord verify failed. Try again.");
-    } finally {
-      setVerifying(false);
-    }
-  };
-
-  // Render helpers for actions
-  const renderActions = (q) => {
-    const key = q.code || String(q.id);
-    const secondsLeft = timers[key] ?? 0;
-    const isDone = completed.includes(q.id) || q.completed;
-
-    // Telegram/Discord verify buttons take precedence if required
-    if (isTelegramReq(q.requirement)) {
-      return (
-        <div className="actions">
-          <button className="btn" disabled={verifying} onClick={() => handleVerifyTelegram()}>
-            {verifying ? "Verifying…" : "Verify Telegram (All)"}
-          </button>
-          <button className="btn ghost" disabled={verifying} onClick={() => handleVerifyTelegram("group")}>
-            Group
-          </button>
-          <button className="btn ghost" disabled={verifying} onClick={() => handleVerifyTelegram("channel")}>
-            Channel
-          </button>
-        </div>
-      );
-    }
-    if (isDiscordReq(q.requirement)) {
-      return (
-        <div className="actions">
-          <button className="btn" disabled={verifying} onClick={handleVerifyDiscord}>
-            {verifying ? "Verifying…" : "Verify Discord"}
-          </button>
-        </div>
-      );
-    }
-
-    // Link / visit quests (secure start → claim)
-    if (q.url && q.active) {
-      return (
-        <div className="actions">
-          {secondsLeft > 0 ? (
-            <button className="btn" disabled>
-              Wait {secondsLeft}s…
-            </button>
-          ) : isDone ? (
-            <button className="btn success" disabled>
-              Completed
-            </button>
-          ) : (
-            <>
-              <button className="btn primary" onClick={() => handleVisit(q)}>
-                Visit
-              </button>
-              <button
-                className="btn ghost"
-                disabled={!!claiming[key]}
-                onClick={() => handleClaim(q)}
-                title="Click after the timer finishes"
-              >
-                {claiming[key] ? "Claiming…" : "Claim"}
-              </button>
-            </>
-          )}
-        </div>
-      );
-    }
-
-    // Fallback: just a disabled “Complete” (we no longer use DEV_COMPLETE)
-    return (
-      <div className="actions">
-        <button className="btn ghost" disabled title="No action available">
-          Complete
-        </button>
-      </div>
-    );
-  };
+  if (loading) return <p>Loading quests...</p>;
+  if (error) return <p>Error: {error}</p>;
 
   return (
-    <div className="page">
-      {/* Background video */}
-      <video autoPlay loop muted playsInline className="bg-video">
-        <source src="/videos/sea-goddess.mp4" type="video/mp4" />
-      </video>
-      <div className="veil" />
-
-      <div className="q-container">
-        {/* Profile strip */}
-        <div className="glass profile-strip">
-          <div>
-            <p className="muted mono">Wallet</p>
-            <p className="mono">{wallet || "—"}</p>
-          </div>
-          <div>
-            <p className="muted mono">XP • Tier • Level</p>
-            <p className="mono">
-              {xp} • {tier} • {level.symbol} {level.name}
-            </p>
-            <XPBar xp={xp} nextXP={level.nextXP || 10000} />
-          </div>
-          <div className="pill">{tier}</div>
-        </div>
-
-        {/* Header + tabs */}
-        <div className="glass-strong q-header">
-          <div className="q-title">
-            <span className="emoji">📜</span>
-            <h1>Quests</h1>
-          </div>
-          <p className="subtitle">Complete tasks. Earn XP. Level up.</p>
-
-          <div className="tabs">
-            {QUEST_TABS.map((type) => (
+    <div style={{ padding: 16 }}>
+      <ProfileWidget />
+      <h1>Quests</h1>
+      <ul>
+        {quests.map((q) => (
+          <li key={q.id} style={{ marginBottom: 8 }}>
+            <span>{q.title || q.id}</span>
+            {q.alreadyClaimed || q.claimed ? (
+              <span style={{ marginLeft: 8 }}>Claimed</span>
+            ) : (
               <button
-                key={type}
-                className={`tab ${activeTab === type ? "active" : ""}`}
-                onClick={() => {
-                  playClick();
-                  setActiveTab(type);
-                }}
+                onClick={() => handleClaim(q.id)}
+                disabled={claiming[q.id]}
+                style={{ marginLeft: 8 }}
               >
-                {type === "all" && "All Quests"}
-                {type === "daily" && "📅 Daily"}
-                {type === "social" && "🌐 Social"}
-                {type === "partner" && "🤝 Partner"}
-                {type === "insider" && "🧠 Insider"}
-                {type === "onchain" && "🧾 Onchain"}
+                {claiming[q.id] ? 'Claiming...' : 'Claim'}
               </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Quest list */}
-        <div className="q-list">
-          {shownQuests.length === 0 ? (
-            <div className="glass quest-card">
-              <p className="quest-title">No quests yet for this category.</p>
-            </div>
-          ) : (
-            shownQuests.map((q) => {
-              return (
-                <div key={q.id} className="glass quest-card">
-                  <div className="q-row">
-                    <span className={`chip ${q.type}`}>
-                      {q.type?.charAt(0).toUpperCase() + q.type?.slice(1)}
-                    </span>
-                    <span className="xp-badge">+{q.xp} XP</span>
-                  </div>
-
-                  <p className="quest-title">{q.title || q.code}</p>
-
-                  {q.url ? (
-                    <div className="muted mono" style={{ wordBreak: "break-all" }}>
-                      {q.url}
-                    </div>
-                  ) : null}
-
-                  {renderActions(q)}
-                </div>
-              );
-            })
-          )}
-        </div>
-
-        {/* Level-up modal */}
-        {showLevelModal && unlocked && (
-          <div className="modal">
-            <div className="glass-strong modal-box">
-              <h2>🎉 Level Up!</h2>
-              <img
-                src={`/images/badges/level-${unlocked.name.toLowerCase().replace(/\s+/g, "-")}.png`}
-                alt={unlocked.name}
-                onError={(e) => {
-                  e.currentTarget.style.display = "none";
-                }}
-              />
-              <p>
-                {unlocked.symbol} You unlocked <strong>{unlocked.name}</strong>!
-              </p>
-              <button className="btn primary" onClick={() => setShowLevelModal(false)}>
-                Close
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* XP modal */}
-        {xpModalOpen && <XPModal xpGained={recentXP} onClose={() => setXPModalOpen(false)} />}
-      </div>
+            )}
+          </li>
+        ))}
+      </ul>
+      <Toast message={toast} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add API client with wallet-aware helpers
- add wallet input, profile widget, toast, and simple quests page
- document backend URL and launch checklist

## Testing
- `npm test` *(fails: window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68baa9182c88832ba456e0d8e16d8c10