### PR TITLE
Clean up quest claiming and profile widget

### DIFF
--- a/src/components/ProfileWidget.js
+++ b/src/components/ProfileWidget.js
@@ -2,27 +2,23 @@ import React, { useEffect, useState } from 'react';
 import { getMe } from '../lib/api';
 
 export default function ProfileWidget() {
-  const [loading, setLoading] = useState(true);
   const [me, setMe] = useState(null);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
   useEffect(() => {
-    (async () => {
-      try {
-        const wallet = localStorage.getItem('wallet') || '';
-        const data = await getMe(wallet);
-        setMe(data);
-      } catch (e) {
-        setError(e.message || 'Failed to load profile');
-      } finally {
-        setLoading(false);
-      }
-    })();
+    const wallet = localStorage.getItem('wallet') || '';
+    getMe(wallet)
+      .then(setMe)
+      .catch((e) => setError(e.message || 'Failed to load profile'))
+      .finally(() => setLoading(false));
   }, []);
 
   if (loading) return <div>Loading profile...</div>;
   if (error) return <div>Error: {error}</div>;
   if (!me) return null;
+
+  const progress = Math.round((me.levelProgress || 0) * 100);
 
   return (
     <div style={{ marginBottom: 16 }}>
@@ -32,7 +28,7 @@ export default function ProfileWidget() {
       <div style={{ background: '#eee', height: 8, borderRadius: 4 }}>
         <div
           style={{
-            width: `${Math.round((me.levelProgress || 0) * 100)}%`,
+            width: `${progress}%`,
             background: '#4caf50',
             height: '100%',
             borderRadius: 4,


### PR DESCRIPTION
## Summary
- simplify profile widget to fetch profile once and render progress bar
- refactor quests page to reuse quest-loading logic and handle claim toasts

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bab52427c8832b99b1c260d71acb63