### PR TITLE
Final launch frontend: wallet-safe quests, clean ProfileWidget, docs & tests

### DIFF
--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -16,4 +16,4 @@ Add the domains:
 
 1. Set wallet to `UQTestWallet123` in the header input.
 2. Claim "Join our Telegram" → XP +40, then re-claim → Already claimed.
-3. Refresh page → XP persists.
+3. Refresh page → XP persists and Profile widget progress reflects backend.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Set the backend URL before starting the app:
 REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
 ```
 
+## Vercel
+
+Deploy on Vercel with custom domains:
+- 7goldencowries.com
+- www.7goldencowries.com
+
+## Manual Test Steps
+
+1. Set wallet to `UQTestWallet123` in the header input.
+2. Go to Quests and claim "Join our Telegram" → XP +40; re-claim → "Already claimed".
+3. Refresh page → XP persists and Profile widget progress reflects backend.
+
 ## Scripts
 
 - `npm start` – run development server

--- a/src/components/ProfileWidget.js
+++ b/src/components/ProfileWidget.js
@@ -2,38 +2,40 @@ import React, { useEffect, useState } from 'react';
 import { getMe } from '../lib/api';
 
 export default function ProfileWidget() {
-  const [me, setMe] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [me, setMe] = useState(null);
   const [error, setError] = useState('');
 
   useEffect(() => {
-    const wallet = localStorage.getItem('wallet') || '';
-    getMe(wallet)
-      .then(setMe)
-      .catch((e) => setError(e.message || 'Failed to load profile'))
-      .finally(() => setLoading(false));
+    (async () => {
+      try {
+        const wallet = localStorage.getItem('wallet') || '';
+        const data = await getMe(wallet);
+        setMe(data);
+      } catch (e) {
+        setError(e.message || 'Failed to load profile');
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, []);
 
   if (loading) return <div>Loading profile...</div>;
   if (error) return <div>Error: {error}</div>;
   if (!me) return null;
 
-  const progress = Math.round((me.levelProgress || 0) * 100);
+  const progressPct = Math.min(100, Math.round((me.levelProgress || 0) * 100));
 
   return (
     <div style={{ marginBottom: 16 }}>
-      <div>
-        Level {me.levelName}, {me.xp} XP, Next: {me.nextXP}
-      </div>
+      <div>Level {me.levelName}, {me.xp} XP, Next: {me.nextXP}</div>
       <div style={{ background: '#eee', height: 8, borderRadius: 4 }}>
-        <div
-          style={{
-            width: `${progress}%`,
-            background: '#4caf50',
-            height: '100%',
-            borderRadius: 4,
-          }}
-        />
+        <div style={{
+          width: `${progressPct}%`,
+          background: '#4caf50',
+          height: '100%',
+          borderRadius: 4,
+        }} />
       </div>
     </div>
   );

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -21,11 +21,20 @@ export default function Quests() {
   };
 
   useEffect(() => {
-    walletRef.current = localStorage.getItem('wallet') || '';
-    (async () => {
+    const syncWallet = async () => {
+      walletRef.current = localStorage.getItem('wallet') || '';
       await loadQuests();
-      setLoading(false);
-    })();
+    };
+
+    // initial load
+    syncWallet().finally(() => setLoading(false));
+
+    // refresh if wallet changes (even in another tab)
+    const onStorage = (e) => {
+      if (e.key === 'wallet') syncWallet();
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
   }, []);
 
   const handleClaim = async (id) => {


### PR DESCRIPTION
## Summary
- streamline ProfileWidget with single state/effect and capped progress bar
- clean wallet handling on quests page with ref and storage listener
- document backend URL, custom domains, and quest claim manual steps

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68babbe10af8832b80ec62ba0c81617a