### PR TITLE
feat(frontend): production hardening—resilient fetch, error panels, referral UI, stable TonConnect, auto-refresh leaderboard, test-api

### DIFF
--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { getQuests, postJSON } from '../utils/api';
+import { getQuests, claimQuest } from '../utils/api';
 import Toast from '../components/Toast';
 import ProfileWidget from '../components/ProfileWidget';
 import './Quests.css';
@@ -61,11 +61,13 @@ export default function Quests() {
   }, []);
 
   const handleClaim = async (id) => {
+    if (claiming[id]) return; // guard duplicate clicks
     setClaiming((c) => ({ ...c, [id]: true }));
     try {
-      await postJSON('/api/quests/claim', { questId: id });
+      await claimQuest(id);
       setToast('Quest claimed');
       await loadQuests();
+      window.dispatchEvent(new Event('profile-updated'));
     } catch (e) {
       setToast(e.message || 'Failed to claim');
     } finally {

--- a/src/pages/TestAPI.js
+++ b/src/pages/TestAPI.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { api, getQuests, getLeaderboard } from "../utils/api";
+import { api, getQuests, getLeaderboard, getMe, getReferralInfo } from "../utils/api";
 export default function TestAPI() {
   const [log, setLog] = useState([]);
   const add = (s) => setLog((x) => [...x, s]);
@@ -17,6 +17,18 @@ export default function TestAPI() {
       add(`✓ /api/leaderboard OK (${(l?.leaders || l || []).length})`);
     } catch (e) {
       add(`✗ /api/leaderboard: ${e.message}`);
+    }
+    try {
+      await getMe();
+      add("✓ /api/users/me OK");
+    } catch (e) {
+      add(`✗ /api/users/me: ${e.message}`);
+    }
+    try {
+      await getReferralInfo();
+      add("✓ /api/referral/me OK");
+    } catch (e) {
+      add(`✗ /api/referral/me: ${e.message}`);
     }
   }
   return (


### PR DESCRIPTION
## Summary
- add robust API helper with 15s timeout, referral endpoints, and claim helpers
- refresh profile widget on quest claim and clamp progress
- extend quests page to guard duplicate claims and notify profile updates
- add more checks on /test-api page

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68badc1a45b4832bbfc491930fe02699