### PR TITLE
fix(frontend): wallet bind retry-safety—cache only on success and dedupe concurrent binds

### DIFF
--- a/src/utils/walletBind.js
+++ b/src/utils/walletBind.js
@@ -1,14 +1,42 @@
 import { bindWallet } from "./api";
 
-let bound = null;
+// Wallet we have successfully bound on this page/session
+let lastSuccessWallet = null;
+// In-flight promises per wallet to prevent duplicate POSTs
+const inflight = new Map();
 
+/**
+ * Ensure the connected wallet is bound to the server session.
+ * Idempotent and safe to call repeatedly. Concurrent calls are deduped.
+ */
 export async function ensureWalletBound(wallet) {
-  if (!wallet || wallet === bound) return;
-  bound = wallet;
+  if (!wallet) return;
+  if (wallet === lastSuccessWallet) return; // already bound successfully
+
+  // Reuse the current in-flight request for this wallet if present
+  if (inflight.has(wallet)) {
+    try {
+      await inflight.get(wallet);
+    } catch {
+      // swallow; caller may call again later
+    }
+    return;
+  }
+
+  const p = (async () => {
+    try {
+      await bindWallet(wallet);        // server should be idempotent
+      lastSuccessWallet = wallet;      // cache ONLY after success
+    } finally {
+      inflight.delete(wallet);         // always clear to allow future retries
+    }
+  })();
+
+  inflight.set(wallet, p);
   try {
-    await bindWallet(wallet);
+    await p;
   } catch (e) {
-    console.error("bind-wallet failed", e);
+    console.error("[wallet] bind failed:", e?.message || e);
+    // do not set lastSuccessWallet on failure; future calls will retry
   }
 }
-


### PR DESCRIPTION
## Summary
- improve wallet binding utility to cache only after successful bind
- dedupe concurrent binds and clear in-flight on settle

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baedaa1738832ba82ea75886c3b205