### PR TITLE
Align socials API helpers and profile wiring

### DIFF
--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -11,7 +11,8 @@ import { unlinkSocial, resyncSocial } from "../utils/socialLinks"; // ✅ RIGHT 
 const DISCORD_INVITE = process.env.REACT_APP_DISCORD_INVITE || "";
 
 // Telegram embed constants
-const TG_BOT_NAME = process.env.REACT_APP_TG_BOT_NAME || "GOLDENCOWRIEBOT";
+const TG_BOT_NAME =
+  process.env.REACT_APP_TELEGRAM_BOT_NAME || "GOLDENCOWRIEBOT";
 const TG_VERIFY_URL = API_URLS.telegramEmbedAuth;
 
 const perksMap = {

--- a/src/pages/TestAPI.js
+++ b/src/pages/TestAPI.js
@@ -20,7 +20,13 @@ export default function TestAPI() {
     }
     try {
       const me = await getMe();
-      add(`✓ /api/users/me: ${JSON.stringify(me.socials || {})}`);
+      const s = me.socials || {};
+      const summary = [
+        `telegram=${s.telegram?.connected ? s.telegram.username : "off"}`,
+        `twitter=${s.twitter?.connected ? s.twitter.username : "off"}`,
+        `discord=${s.discord?.connected ? s.discord.username : "off"}`,
+      ].join(", ");
+      add(`✓ /api/users/me: ${summary}`);
     } catch (e) {
       add(`✗ /api/users/me: ${e.message}`);
     }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -57,7 +57,26 @@ export function getLeaderboard({ signal } = {}) {
   return jsonFetch("/api/leaderboard", { signal });
 }
 
-export function getMe({ signal } = {}) {
+/**
+ * Shape returned from GET /api/users/me.
+ * @typedef {Object} MeResponse
+ * @property {string} wallet
+ * @property {number} xp
+ * @property {string} level
+ * @property {number} levelProgress
+ * @property {Object} socials
+ * @property {{connected:boolean, username:(string|null)}} socials.telegram
+ * @property {{connected:boolean, username:(string|null), id:(string|null)}} socials.twitter
+ * @property {{connected:boolean, username:(string|null), id:(string|null)}} socials.discord
+ */
+
+/**
+ * Fetch the current user's profile.
+ * @param {Object} [opts]
+ * @param {AbortSignal} [opts.signal]
+ * @returns {Promise<MeResponse>}
+ */
+export async function getMe({ signal } = {}) {
   return jsonFetch("/api/users/me", { signal });
 }
 

--- a/src/utils/socialLinks.js
+++ b/src/utils/socialLinks.js
@@ -7,8 +7,7 @@ import { api } from "./api";
  * @param {'twitter'|'telegram'|'discord'} provider
  */
 export async function unlinkSocial(provider) {
-  const { data } = await api.post(`/api/social/${provider}/unlink`);
-  return data; // { ok: true } or { error }
+  return api.post(`/api/social/${provider}/unlink`); // { ok: true } or { error }
 }
 
 /**
@@ -17,6 +16,5 @@ export async function unlinkSocial(provider) {
  * @param {'twitter'|'telegram'|'discord'} provider
  */
 export async function resyncSocial(provider) {
-  const { data } = await api.post(`/api/social/${provider}/resync`);
-  return data; // { ok: true, handle: '...' } or { error }
+  return api.post(`/api/social/${provider}/resync`); // { ok: true, handle: '...' }
 }


### PR DESCRIPTION
## Summary
- document unified `/api/users/me` response and export async `getMe`
- use `REACT_APP_TELEGRAM_BOT_NAME` for embedded Telegram login
- improve `/test-api` logging and return social link API results directly

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb551178ac832b8fff94698a3484dc