### PR TITLE
feat: improve error handling and add caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Base URL of the 7GoldenCowries backend API
+REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
+
+# Optional: override the TonConnect manifest location
+# REACT_APP_TONCONNECT_MANIFEST_URL=https://example.com/tonconnect-manifest.json

--- a/README.md
+++ b/README.md
@@ -2,15 +2,25 @@
 
 Minimal React app for the 7GoldenCowries launch.
 
-## Configuration
+## Setup
 
-Set the backend URL before starting the app:
-
-```
-REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
-```
+1. Install dependencies: `npm install`
+2. Copy `.env.example` to `.env` and set `REACT_APP_API_URL`.
+3. Start development server: `npm start`
 
 TonConnect manifest is served from the same origin at `/tonconnect-manifest.json`. `www` permanently (308) redirects to the apex domain.
+
+## API
+
+The frontend talks to the backend REST API:
+
+- `GET /api/users/:wallet` – fetch profile (`xp`, `levelName`, `progress`)
+- `POST /api/quests/claim` – claim quest; returns `{ alreadyClaimed: boolean }`
+- `GET /api/meta/progression` – XP progression metadata
+
+### Deprecation
+
+Legacy endpoints `/quests` and `/complete` are deprecated and will be removed after launch. Use `/api/quests` and `/api/quests/claim` instead.
 
 ## Vercel
 

--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import './Leaderboard.css';
-
-const API = process.env.REACT_APP_API_URL;
+import { getLeaderboard } from './utils/api';
 
 const lore = {
   "Shellborn": "Born from tide and shell — a humble beginning.",
@@ -15,12 +14,18 @@ const lore = {
 
 const Leaderboard = () => {
   const [leaders, setLeaders] = useState([]);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    fetch(`${API}/leaderboard`)
-      .then(res => res.json())
-      .then(data => setLeaders(data.top || []))
-      .catch(console.error);
+    let mounted = true;
+    getLeaderboard()
+      .then((data) => mounted && setLeaders(data.top || []))
+      .catch((e) => {
+        if (mounted) setError(e.message || 'Failed to load leaderboard');
+      });
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   return (
@@ -28,7 +33,9 @@ const Leaderboard = () => {
       <h1>🏆 Cowrie Leaderboard</h1>
       <p className="subtitle">Top explorers across the Seven Isles</p>
 
-      {leaders.length === 0 ? (
+      {error ? (
+        <p className="error">{error}</p>
+      ) : leaders.length === 0 ? (
         <p className="loading">Loading leaderboard...</p>
       ) : (
         <div className="leaderboard-list">
@@ -39,7 +46,7 @@ const Leaderboard = () => {
                 <img
                   src={`/images/badges/level-${user.name.toLowerCase().replace(/\s+/g, '-')}.png`}
                   alt={user.name}
-                  onError={(e) => e.target.src = '/images/badges/unranked.png'}
+                  onError={(e) => (e.target.src = '/images/badges/unranked.png')}
                   className="user-badge"
                 />
                 <div className="user-meta">

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -64,12 +64,16 @@ export default function Quests() {
     if (claiming[id]) return; // guard duplicate clicks
     setClaiming((c) => ({ ...c, [id]: true }));
     try {
-      await claimQuest(id);
-      setToast('Quest claimed');
+      const res = await claimQuest(id);
+      if (res?.alreadyClaimed) {
+        setToast('Already claimed');
+      } else {
+        setToast('Quest claimed');
+      }
       await sync();
       window.dispatchEvent(new Event('profile-updated'));
     } catch (e) {
-      setToast(e.message || 'Failed to claim');
+      setToast(e.message || 'Failed to claim quest');
     } finally {
       setClaiming((c) => ({ ...c, [id]: false }));
       setTimeout(() => setToast(''), 3000);


### PR DESCRIPTION
## Summary
- cache quests, leaderboard and profile fetches for 60s
- show friendly messages for already-claimed quests and API failures
- document setup, API endpoints and legacy endpoint deprecation

## Testing
- `npm test -- --watchAll=false`
- `npx cypress run` *(fails: 403 Forbidden fetching cypress)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6215670c832b9e2f8b1cbc657228