### PR TITLE
feat: add client-side Twitter proof submission

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@ REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
 
 # Optional: override the TonConnect manifest location
 # REACT_APP_TONCONNECT_MANIFEST_URL=https://example.com/tonconnect-manifest.json
+
+# Twitter/X quest verification targets
+# (used by backend, included here for reference)
+X_TARGET_HANDLE=7goldencowries
+X_TARGET_TWEET_URL=https://x.com/7goldencowries/status/123456789
+X_REQUIRED_HASHTAG=#7GC

--- a/src/components/ProofModal.js
+++ b/src/components/ProofModal.js
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { submitQuestProof } from '../utils/api';
+
+export default function ProofModal({ quest, onClose, onSuccess }) {
+  const [url, setUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!quest) return null;
+
+  const handleSubmit = async () => {
+    if (!url) {
+      setError('URL required');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await submitQuestProof(quest.id, url);
+      onSuccess && onSuccess(res);
+      onClose();
+    } catch (e) {
+      setError(e.message || 'Failed to submit proof');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal" onClick={onClose}>
+      <div className="glass-strong modal-box" onClick={(e) => e.stopPropagation()}>
+        <h2 style={{ marginTop: 0 }}>Submit Proof</h2>
+        <p className="muted" style={{ marginBottom: 12 }}>
+          Paste the link to your tweet or quote here.
+        </p>
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://x.com/username/status/1234567890"
+          style={{
+            width: '100%',
+            padding: '10px',
+            borderRadius: '8px',
+            border: '1px solid rgba(255,255,255,0.2)',
+            background: 'rgba(0,0,0,0.2)',
+            color: '#eaf2ff',
+          }}
+        />
+        {error && (
+          <p className="muted" style={{ color: '#ff8a8a', marginTop: 8 }}>
+            {error}
+          </p>
+        )}
+        <div className="actions" style={{ marginTop: 16 }}>
+          <button className="btn ghost" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            className="btn primary"
+            onClick={handleSubmit}
+            disabled={submitting}
+          >
+            {submitting ? 'Submitting…' : 'Submit'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Quests.css
+++ b/src/pages/Quests.css
@@ -164,6 +164,9 @@
 .chip.partner { color: #ffe9a6; }
 .chip.insider { color: #f7c2ff; }
 .chip.onchain { color: #cbd4ff; }
+.chip.pending { color: #ffe9a6; border-color: rgba(255, 216, 106, 0.35); background: rgba(255, 216, 106, 0.13); }
+.chip.verified { color: #8affcb; border-color: rgba(23, 160, 120, 0.45); background: rgba(23, 160, 120, 0.18); }
+.chip.rejected { color: #ff9a9a; border-color: rgba(255, 80, 80, 0.45); background: rgba(255, 80, 80, 0.18); }
 
 .xp-badge {
   font-size: 12px;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -138,6 +138,15 @@ export function claimQuest(id, opts = {}) {
   });
 }
 
+export function submitQuestProof(id, url, opts = {}) {
+  return postJSON("/api/quests/submit-proof", { questId: id, url }, opts).then(
+    (res) => {
+      clearUserCache();
+      return res;
+    }
+  );
+}
+
 export function bindWallet(wallet, opts = {}) {
   return postJSON("/api/session/bind-wallet", { wallet }, opts).then((res) => {
     clearUserCache();
@@ -188,6 +197,7 @@ export const api = {
   startDiscord,
   startTwitter,
   claimQuest,
+  submitQuestProof,
   clearUserCache,
   getReferralInfo,
   createReferral,


### PR DESCRIPTION
## Summary
- allow quests to submit Twitter proof links
- add modal for proof submission and status chips
- expose proof submission API util and config placeholders

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bba7f9a378832b9c71c092a38b7aec