### PR TITLE
Fix wallet refresh and proof modal cancel

### DIFF
--- a/src/components/ProofModal.js
+++ b/src/components/ProofModal.js
@@ -122,7 +122,12 @@ export default function ProofModal({ quest, wallet, onClose, onVerified }) {
             <p className="muted" style={{ marginTop: 8 }}>Verifying…</p>
           )}
           <div className="actions" style={{ marginTop: 16 }}>
-            <button className="btn ghost" onClick={onClose} disabled={submitting || verifying}>
+            <button
+              type="button"
+              className="btn ghost"
+              onClick={onClose}
+              disabled={submitting || verifying}
+            >
               Cancel
             </button>
             <button


### PR DESCRIPTION
## Summary
- read wallet from localStorage when checking proof status or claiming quests
- re-sync quests on wallet updates within the same tab
- prevent ProofModal cancel from submitting the form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbf7e18e98832b99e7fe9240013170