### PR TITLE
feat: support manual quest proof submission

### DIFF
--- a/src/components/ProofModal.js
+++ b/src/components/ProofModal.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { submitQuestProof } from '../utils/api';
 
-export default function ProofModal({ quest, onClose, onSuccess }) {
+export default function ProofModal({ quest, wallet, onClose, onSuccess, onError }) {
   const [url, setUrl] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -15,11 +15,13 @@ export default function ProofModal({ quest, onClose, onSuccess }) {
     }
     setSubmitting(true);
     try {
-      const res = await submitQuestProof(quest.id, url);
+      const res = await submitQuestProof(quest.id, wallet, url);
       onSuccess && onSuccess(res);
       onClose();
     } catch (e) {
-      setError(e.message || 'Failed to submit proof');
+      const message = e.message || 'Failed to submit proof';
+      setError(message);
+      onError && onError(message);
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -102,11 +102,6 @@ export default function Quests() {
       : quests.filter((q) => (q.type || '').toLowerCase() === activeTab);
 
   const handleProof = (q) => {
-    if (!me?.socials?.twitter?.connected) {
-      setToast('Connect Twitter first');
-      setTimeout(() => setToast(''), 3000);
-      return;
-    }
     setProofQuest(q);
   };
 
@@ -115,6 +110,11 @@ export default function Quests() {
     setTimeout(() => setToast(''), 3000);
     sync();
     window.dispatchEvent(new Event('profile-updated'));
+  };
+
+  const onProofError = (msg) => {
+    setToast(msg || 'Failed to submit proof');
+    setTimeout(() => setToast(''), 3000);
   };
 
   if (loading) return <div className="loading">Loading quests…</div>;
@@ -199,7 +199,7 @@ export default function Quests() {
                         <button
                           className="btn primary"
                           onClick={() => handleProof(q)}
-                          disabled={!!claiming[q.id] || !me?.socials?.twitter?.connected}
+                          disabled={!!claiming[q.id]}
                         >
                           Submit proof
                         </button>
@@ -238,6 +238,8 @@ export default function Quests() {
             quest={proofQuest}
             onClose={() => setProofQuest(null)}
             onSuccess={onProofSubmitted}
+            onError={onProofError}
+            wallet={walletRef.current}
           />
         )}
       </div>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -138,8 +138,8 @@ export function claimQuest(id, opts = {}) {
   });
 }
 
-export function submitQuestProof(id, url, opts = {}) {
-  return postJSON("/api/quests/submit-proof", { questId: id, url }, opts).then(
+export function submitQuestProof(id, wallet, url, opts = {}) {
+  return postJSON("/api/proofs", { quest_id: id, wallet, url }, opts).then(
     (res) => {
       clearUserCache();
       return res;


### PR DESCRIPTION
## Summary
- allow submitting manual proof URLs for quests
- post quest proof to `/api/proofs` with quest and wallet details
- surface toast notifications for proof submission outcomes

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bc1019f4ec832ba010a18b3b3b6e88