### PR TITLE
Refresh data after quest claim

### DIFF
--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -84,9 +84,15 @@ export default function Quests() {
       if (res?.alreadyClaimed) {
         setToast('Already claimed');
       } else {
-        setToast('Quest claimed');
+        setToast(`Quest claimed! +${res?.xp ?? 0} XP`);
       }
-      await sync();
+      const [meData, questsData] = await Promise.all([getMe(), getQuests()]);
+      if (mountedRef.current) {
+        setMe(meData);
+        setQuests(questsData?.quests ?? []);
+        setCompleted(questsData?.completed ?? []);
+        setXp(questsData?.xp ?? 0);
+      }
       window.dispatchEvent(new Event('profile-updated'));
     } catch (e) {
       setToast(e.message || 'Failed to claim quest');

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Quests from './Quests';
+import { getQuests, claimQuest, getMe } from '../utils/api';
+
+jest.mock('../utils/api');
+
+describe('Quests page claiming', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('claiming a quest refreshes data and shows awarded XP', async () => {
+    getQuests.mockResolvedValueOnce({
+      quests: [{ id: 1, xp: 10, active: 1 }],
+      completed: [],
+      xp: 0,
+    });
+    getMe.mockResolvedValueOnce({
+      wallet: 'w',
+      xp: 0,
+      level: '1',
+      levelProgress: 0,
+      socials: {},
+    });
+
+    render(<Quests />);
+
+    const claimBtn = await screen.findByText('Claim');
+
+    claimQuest.mockResolvedValue({ xp: 50 });
+    getMe.mockResolvedValueOnce({
+      wallet: 'w',
+      xp: 50,
+      level: '1',
+      levelProgress: 0,
+      socials: {},
+    });
+    getQuests.mockResolvedValueOnce({
+      quests: [{ id: 1, xp: 10, active: 1, alreadyClaimed: true }],
+      completed: [1],
+      xp: 50,
+    });
+
+    await userEvent.click(claimBtn);
+
+    await waitFor(() => expect(getMe).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getQuests).toHaveBeenCalledTimes(2));
+
+    expect(await screen.findByText('Claimed')).toBeDisabled();
+    expect(screen.getByText(/\+50 XP/)).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- refresh quests and user profile after claiming a quest and show awarded XP in toast
- add regression test covering quest claim refresh behaviour

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc3ee2d180832b92284f9fb07a7f4a