### PR TITLE
Ensure quests have visit button

### DIFF
--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -242,7 +242,7 @@ export default function Quests() {
                           Submit proof
                         </button>
                       )}
-                      {q.url && typeof q.proofStatus === 'undefined' && (
+                      {q.url && (
                         <a
                           className="btn primary"
                           href={q.url}

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -51,5 +51,25 @@ describe('Quests page claiming', () => {
     expect(await screen.findByText('Claimed')).toBeDisabled();
     expect(screen.getByText(/\+50 XP/)).toBeInTheDocument();
   });
+
+  test('shows Visit button when quest has a URL', async () => {
+    getQuests.mockResolvedValueOnce({
+      quests: [{ id: 1, xp: 10, active: 1, url: 'https://example.com', proofStatus: 'pending' }],
+      completed: [],
+      xp: 0,
+    });
+    getMe.mockResolvedValueOnce({
+      wallet: 'w',
+      xp: 0,
+      level: '1',
+      levelProgress: 0,
+      socials: {},
+    });
+
+    render(<Quests />);
+
+    const visitBtn = await screen.findByText('Visit');
+    expect(visitBtn).toHaveAttribute('href', 'https://example.com');
+  });
 });
 


### PR DESCRIPTION
## Summary
- Always show a Visit button on quests with links so users can open quest pages directly
- Add tests verifying Visit button appears when quests include URLs

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bc449f37d0832bb44b95f46dc95b21