### PR TITLE
feat: enrich quests with URLs and proofs

### DIFF
--- a/backend/migrations/001_add_url_and_seed_quests.sql
+++ b/backend/migrations/001_add_url_and_seed_quests.sql
@@ -1,0 +1,15 @@
+-- Add url column to quests table if it does not exist
+ALTER TABLE quests ADD COLUMN IF NOT EXISTS url TEXT;
+
+-- Backfill urls for existing quests
+UPDATE quests SET url='https://x.com/7goldencowries' WHERE id=1 AND (url IS NULL OR url='');
+UPDATE quests SET url='https://x.com/7goldencowries/status/194759' WHERE id=2 AND (url IS NULL OR url='');
+UPDATE quests SET url='https://x.com/7goldencowries/status/194759' WHERE id=3 AND (url IS NULL OR url='');
+UPDATE quests SET url='https://t.me/7goldencowries' WHERE id=4 AND (url IS NULL OR url='');
+UPDATE quests SET url='/quests/onchain' WHERE id=5 AND (url IS NULL OR url='');
+
+-- Seed daily quests (ids 41 and 42)
+INSERT OR IGNORE INTO quests (id, title, type, xp, url, active)
+VALUES
+  (41, 'Sample Daily Quest A', 'link', 20, 'https://example.com/daily1', 1),
+  (42, 'Sample Daily Quest B', 'link', 30, 'https://example.com/daily2', 1);

--- a/backend/src/routes/quests.js
+++ b/backend/src/routes/quests.js
@@ -1,0 +1,44 @@
+const express = require('express');
+
+function categoryFor(q) {
+  if ([1, 2, 3].includes(q.id)) return 'Social';
+  if (q.id === 4) return 'Partner';
+  if (q.id === 5) return 'Onchain';
+  if ([41, 42].includes(q.id)) return 'Daily';
+  return 'All';
+}
+
+function createRouter(db, { awardQuest, clearUserCache } = {}) {
+  const router = express.Router();
+
+  router.get('/', (req, res) => {
+    const rows = db.prepare('SELECT id, title, type, xp, active, sort, url FROM quests').all();
+    const quests = rows.map((q) => ({ ...q, category: categoryFor(q) }));
+    res.json({ quests });
+  });
+
+  router.post('/:id/proofs', (req, res) => {
+    const id = Number(req.params.id);
+    const { wallet, vendor, url } = req.body || {};
+    const quest = db.prepare('SELECT id FROM quests WHERE id = ?').get(id);
+    if (!quest) return res.status(404).json({ error: 'Quest not found' });
+    db.prepare('INSERT INTO quest_proofs (quest_id, wallet, vendor, url, updated_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)').run(id, wallet, vendor, url);
+    res.json({ ok: true });
+  });
+
+  router.post('/:id/claim', async (req, res) => {
+    const id = Number(req.params.id);
+    const wallet = req.body && req.body.wallet;
+    try {
+      const result = await (awardQuest ? awardQuest(id, wallet) : Promise.resolve({ xp: 0 }));
+      if (clearUserCache && wallet) clearUserCache(wallet);
+      res.json({ xp: result.xp, status: 'ok', alreadyClaimed: result.alreadyClaimed });
+    } catch (e) {
+      res.status(400).json({ error: e.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createRouter, categoryFor };

--- a/backend/src/routes/quests.ts
+++ b/backend/src/routes/quests.ts
@@ -1,0 +1,46 @@
+import type { Request, Response } from 'express';
+import express from 'express';
+
+export function categoryFor(q: { id: number }) {
+  if ([1, 2, 3].includes(q.id)) return 'Social';
+  if (q.id === 4) return 'Partner';
+  if (q.id === 5) return 'Onchain';
+  if ([41, 42].includes(q.id)) return 'Daily';
+  return 'All';
+}
+
+export function createRouter(db: any, opts: { awardQuest?: Function; clearUserCache?: Function } = {}) {
+  const { awardQuest, clearUserCache } = opts;
+  const router = express.Router();
+
+  router.get('/', (req: Request, res: Response) => {
+    const rows = db.prepare('SELECT id, title, type, xp, active, sort, url FROM quests').all();
+    const quests = rows.map((q: any) => ({ ...q, category: categoryFor(q) }));
+    res.json({ quests });
+  });
+
+  router.post('/:id/proofs', (req: Request, res: Response) => {
+    const id = Number(req.params.id);
+    const { wallet, vendor, url } = req.body || {};
+    const quest = db.prepare('SELECT id FROM quests WHERE id = ?').get(id);
+    if (!quest) return res.status(404).json({ error: 'Quest not found' });
+    db.prepare('INSERT INTO quest_proofs (quest_id, wallet, vendor, url, updated_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)').run(id, wallet, vendor, url);
+    res.json({ ok: true });
+  });
+
+  router.post('/:id/claim', async (req: Request, res: Response) => {
+    const id = Number(req.params.id);
+    const wallet = req.body && req.body.wallet;
+    try {
+      const result = await (awardQuest ? awardQuest(id, wallet) : Promise.resolve({ xp: 0 }));
+      if (clearUserCache && wallet) clearUserCache(wallet);
+      res.json({ xp: result.xp, status: 'ok', alreadyClaimed: result.alreadyClaimed });
+    } catch (e: any) {
+      res.status(400).json({ error: e.message });
+    }
+  });
+
+  return router;
+}
+
+export default createRouter;

--- a/src/components/ProofModal.js
+++ b/src/components/ProofModal.js
@@ -3,6 +3,7 @@ import { submitQuestProof } from '../utils/api';
 
 export default function ProofModal({ quest, wallet, onClose, onSuccess, onError }) {
   const [url, setUrl] = useState('');
+  const [vendor, setVendor] = useState('twitter');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
@@ -15,7 +16,7 @@ export default function ProofModal({ quest, wallet, onClose, onSuccess, onError 
     }
     setSubmitting(true);
     try {
-      const res = await submitQuestProof(quest.id, wallet, url);
+      const res = await submitQuestProof(quest.id, wallet, vendor, url);
       onSuccess && onSuccess(res);
       onClose();
     } catch (e) {
@@ -34,6 +35,23 @@ export default function ProofModal({ quest, wallet, onClose, onSuccess, onError 
         <p className="muted" style={{ marginBottom: 12 }}>
           Paste the link to your tweet or quote here.
         </p>
+        <select
+          value={vendor}
+          onChange={(e) => setVendor(e.target.value)}
+          style={{
+            width: '100%',
+            padding: '10px',
+            borderRadius: '8px',
+            border: '1px solid rgba(255,255,255,0.2)',
+            background: 'rgba(0,0,0,0.2)',
+            color: '#eaf2ff',
+            marginBottom: 8,
+          }}
+        >
+          <option value="twitter">Twitter</option>
+          <option value="telegram">Telegram</option>
+          <option value="discord">Discord</option>
+        </select>
         <input
           type="text"
           value={url}

--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -1,0 +1,98 @@
+import React from 'react';
+
+export default function QuestCard({ quest, onClaim, onProof, claiming }) {
+  const q = quest;
+  return (
+    <div className="glass quest-card">
+      <div className="q-row">
+        {q.type === 'link' ? (
+          q.url ? (
+            <a
+              href={q.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`chip ${q.type}`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              Link
+            </a>
+          ) : (
+            <span className={`chip ${q.type}`}>Link</span>
+          )
+        ) : (
+          <span className={`chip ${q.type}`}>
+            {q.type?.charAt(0).toUpperCase() + q.type?.slice(1)}
+          </span>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {typeof q.proofStatus === 'string' && (
+            <span className={`chip ${q.proofStatus}`}>
+              {q.proofStatus.charAt(0).toUpperCase() + q.proofStatus.slice(1)}
+            </span>
+          )}
+          <span className="xp-badge">+{q.xp} XP</span>
+        </div>
+      </div>
+      <p className="quest-title">
+        {q.url ? (
+          <a
+            href={q.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {q.title || q.id}
+          </a>
+        ) : (
+          q.title || q.id
+        )}
+      </p>
+      {q.url ? (
+        <div className="muted mono" style={{ wordBreak: 'break-all' }}>
+          {q.url}
+        </div>
+      ) : null}
+      <div className="actions">
+        {q.url ? (
+          <a
+            className="btn primary"
+            href={q.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Start
+          </a>
+        ) : (
+          <button className="btn primary" disabled title="Coming soon">
+            Start
+          </button>
+        )}
+        {typeof q.proofStatus !== 'undefined' && (
+          <button
+            className="btn primary"
+            onClick={() => onProof(q)}
+            disabled={claiming}
+          >
+            Submit proof
+          </button>
+        )}
+        {q.alreadyClaimed || q.claimed ? (
+          <button className="btn success" disabled>
+            Claimed
+          </button>
+        ) : (
+          <button
+            className="btn ghost"
+            onClick={() => onClaim(q.id)}
+            disabled={
+              claiming ||
+              (typeof q.proofStatus !== 'undefined' && q.proofStatus !== 'verified')
+            }
+          >
+            {claiming ? 'Claiming...' : 'Claim'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WalletInput.js
+++ b/src/components/WalletInput.js
@@ -11,6 +11,7 @@ export default function WalletInput() {
   const onChange = (e) => setValue(e.target.value);
   const onBlur = () => {
     localStorage.setItem('wallet', value.trim());
+    window.dispatchEvent(new Event('wallet-changed'));
   };
 
   return (

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -52,7 +52,7 @@ describe('Quests page claiming', () => {
     expect(screen.getByText(/\+50 XP/)).toBeInTheDocument();
   });
 
-  test('shows Visit button when quest has a URL', async () => {
+  test('shows Start button when quest has a URL', async () => {
     getQuests.mockResolvedValueOnce({
       quests: [{ id: 1, xp: 10, active: 1, url: 'https://example.com', proofStatus: 'pending' }],
       completed: [],
@@ -68,8 +68,8 @@ describe('Quests page claiming', () => {
 
     render(<Quests />);
 
-    const visitBtn = await screen.findByText('Visit');
-    expect(visitBtn).toHaveAttribute('href', 'https://example.com');
+    const startBtn = await screen.findByText('Start');
+    expect(startBtn).toHaveAttribute('href', 'https://example.com');
   });
 });
 

--- a/src/quests.api.test.js
+++ b/src/quests.api.test.js
@@ -1,0 +1,72 @@
+/** @jest-environment node */
+const express = require('express');
+const http = require('http');
+const { createRouter } = require('../backend/src/routes/quests.js');
+
+function call(app, method, path, body) {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const opts = {
+        method,
+        hostname: '127.0.0.1',
+        port: server.address().port,
+        path,
+        headers: { 'Content-Type': 'application/json' },
+      };
+      const req = http.request(opts, (res) => {
+        let data = '';
+        res.on('data', (d) => (data += d));
+        res.on('end', () => {
+          server.close();
+          resolve({ status: res.statusCode, body: data ? JSON.parse(data) : null });
+        });
+      });
+      if (body) req.write(JSON.stringify(body));
+      req.end();
+    });
+  });
+}
+
+describe('quests API', () => {
+  test('GET /api/quests returns category mapping', async () => {
+    const quests = [{ id: 1, title: 'q1', type: 'link', xp: 10, active: 1, sort: 0, url: 'u' }];
+    const db = {
+      prepare: () => ({
+        all: () => quests,
+        get: (id) => quests.find((q) => q.id === id),
+        run: () => {},
+      }),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use('/api/quests', createRouter(db));
+    const res = await call(app, 'GET', '/api/quests');
+    expect(res.body.quests[0].category).toBe('Social');
+  });
+
+  test('POST /api/quests/:id/proofs inserts proof', async () => {
+    const proofs = [];
+    const db = {
+      prepare: (sql) => {
+        if (sql.startsWith('SELECT')) {
+          return { get: () => ({ id: 1 }) };
+        }
+        return {
+          run: (questId, wallet, vendor, url) => {
+            proofs.push({ questId, wallet, vendor, url });
+          },
+        };
+      },
+    };
+    const app = express();
+    app.use(express.json());
+    app.use('/api/quests', createRouter(db));
+    const res = await call(app, 'POST', '/api/quests/1/proofs', {
+      wallet: 'w',
+      vendor: 'twitter',
+      url: 'u',
+    });
+    expect(res.status).toBe(200);
+    expect(proofs[0]).toEqual({ questId: 1, wallet: 'w', vendor: 'twitter', url: 'u' });
+  });
+});

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -132,14 +132,14 @@ export async function postJSON(path, body, opts = {}) {
 }
 
 export function claimQuest(id, opts = {}) {
-  return postJSON("/api/quests/claim", { questId: id }, opts).then((res) => {
+  return postJSON(`/api/quests/${id}/claim`, {}, opts).then((res) => {
     clearUserCache();
     return res;
   });
 }
 
-export function submitQuestProof(id, wallet, url, opts = {}) {
-  return postJSON("/api/proofs", { quest_id: id, wallet, url }, opts).then(
+export function submitQuestProof(id, wallet, vendor, url, opts = {}) {
+  return postJSON(`/api/quests/${id}/proofs`, { wallet, vendor, url }, opts).then(
     (res) => {
       clearUserCache();
       return res;


### PR DESCRIPTION
## Summary
- add migration to backfill quest URLs and seed daily quests
- expose quest URLs and categories, handle proofs and claims
- enable Start buttons, wallet refresh, and proof vendor selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc496bae68832b809c5582ea29d968