### PR TITLE
Sync wallet across tabs and show referral code

### DIFF
--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -132,6 +132,24 @@ export default function Profile() {
     ensureWalletBound(tonWallet);
   }, [tonWallet]);
 
+  // Keep address in sync across tabs when wallet changes
+  useEffect(() => {
+    const update = () => {
+      const w = localStorage.getItem('wallet') || '';
+      setAddress((a) => (a !== w ? w : a));
+      loadMe();
+    };
+    const onStorage = (e) => {
+      if (e.key === 'wallet') update();
+    };
+    window.addEventListener('wallet:changed', update);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener('wallet:changed', update);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, [loadMe]);
+
   const badgeSrc = useMemo(() => {
     const slug = (level.name || "unranked").toLowerCase().replace(/\s+/g, "-");
     return `/images/badges/level-${slug}.png`;
@@ -565,23 +583,23 @@ export default function Profile() {
               <button
                 className="connect-btn"
                 onClick={connectTwitter}
-                disabled={connecting.twitter}
+                disabled={connecting.twitter || !!twitter}
               >
-                🐦 Connect X (Twitter)
+                {twitter ? '✅ X (Twitter)' : '🐦 Connect X (Twitter)'}
               </button>
               <button
                 className="connect-btn"
                 onClick={connectTelegram}
-                disabled={connecting.telegram}
+                disabled={connecting.telegram || !!telegram}
               >
-                📣 Connect Telegram
+                {telegram ? '✅ Telegram' : '📣 Connect Telegram'}
               </button>
               <button
                 className="connect-btn"
                 onClick={connectDiscord}
-                disabled={connecting.discord}
+                disabled={connecting.discord || !!discord}
               >
-                🎮 Connect Discord
+                {discord ? '✅ Discord' : '🎮 Connect Discord'}
               </button>
             </div>
 

--- a/src/pages/Referrals.js
+++ b/src/pages/Referrals.js
@@ -5,6 +5,7 @@ import "../App.css";
 
 import { playClick } from "../utils/sounds";
 import { getReferralCode, getReferralStats } from "../utils/referrals";
+import { getReferralInfo } from "../utils/api";
 
 function Toast({ msg, type = "info", onClose }) {
   if (!msg) return null;
@@ -43,8 +44,12 @@ export default function Referrals() {
   async function load() {
     setLoading(true);
     try {
-      const stats = await getReferralStats(); // { code, referees: [...] }
-      if (stats?.code) setCode(stats.code);
+      const [info, stats] = await Promise.all([
+        getReferralInfo().catch(() => null),
+        getReferralStats().catch(() => null),
+      ]);
+      if (info?.referral_code) setCode(info.referral_code);
+      else if (stats?.code) setCode(stats.code);
       else {
         const c = await getReferralCode();
         if (c) setCode(c);


### PR DESCRIPTION
## Summary
- keep profile wallet synced across tabs by listening to wallet change events
- disable connected social buttons with a checkmark
- fetch and display referral code via /api/referral/me

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bc65166650832bad4f06bc4fd9dd29