### PR TITLE
feat: add wallet connect component with logout and error handling

### DIFF
--- a/src/components/LeftNav.css
+++ b/src/components/LeftNav.css
@@ -53,6 +53,8 @@
   z-index: 99;
   transform: translateX(0);
   transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Drawer behavior on small screens */
@@ -107,6 +109,13 @@
 .nav-item.active{
   outline: 1px solid rgba(255,212,102,.25);
   box-shadow: 0 0 0 1px rgba(255,212,102,.08) inset, 0 8px 20px rgba(255,212,102,.12);
+}
+
+/* Wallet connect area at bottom */
+.nav-wallet{
+  margin-top: auto;
+  display: flex;
+  justify-content: center;
 }
 
 /* Push main content so it doesn't sit under the fixed sidebar (desktop only) */

--- a/src/components/LeftNav.jsx
+++ b/src/components/LeftNav.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link, NavLink } from "react-router-dom";
 import "./LeftNav.css";
 import logo from "../assets/logo.svg";
+import WalletConnect from "./WalletConnect";
 
 export default function LeftNav() {
   return (
@@ -20,6 +21,10 @@ export default function LeftNav() {
         <NavLink to="/profile" className="nav-item"><span>🔗</span><span>Profile</span></NavLink>
         <NavLink to="/isles" className="nav-item"><span>🌱</span><span>Isles</span></NavLink>
       </nav>
+
+      <div className="nav-wallet">
+        <WalletConnect />
+      </div>
     </aside>
   );
 }

--- a/src/components/WalletConnect.jsx
+++ b/src/components/WalletConnect.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import { useTonAddress, useTonConnectUI } from "@tonconnect/ui-react";
+import Toast from "./Toast";
+import "./ConnectButtons.css";
+import { useWallet } from "../context/WalletContext";
+
+/**
+ * WalletConnect component: shows a connect or disconnect button using
+ * TonConnect v2. Basic error handling is provided via a temporary toast.
+ */
+export default function WalletConnect({ className = "" }) {
+  const [tonConnectUI] = useTonConnectUI();
+  const address = useTonAddress();
+  const { disconnect: ctxDisconnect } = useWallet();
+  const [toast, setToast] = useState("");
+
+  const showError = (msg) => {
+    setToast(msg);
+    setTimeout(() => setToast(""), 3000);
+  };
+
+  const connect = async () => {
+    try {
+      await tonConnectUI.openModal();
+    } catch (e) {
+      console.error("[WalletConnect] connect error", e);
+      showError(e?.message || "Wallet connection failed");
+    }
+  };
+
+  const disconnect = async () => {
+    try {
+      await ctxDisconnect();
+    } catch (e) {
+      console.error("[WalletConnect] disconnect error", e);
+      showError(e?.message || "Failed to disconnect");
+    }
+  };
+
+  return (
+    <div className={`connect-buttons ${className}`.trim()}>
+      {address ? (
+        <button type="button" className="connect-btn" onClick={disconnect}>
+          Disconnect {address.slice(0, 4)}…{address.slice(-4)}
+        </button>
+      ) : (
+        <button type="button" className="connect-btn" onClick={connect}>
+          Connect Wallet
+        </button>
+      )}
+      <Toast message={toast} />
+    </div>
+  );
+}

--- a/src/context/WalletContext.js
+++ b/src/context/WalletContext.js
@@ -1,13 +1,27 @@
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
-import { useTonAddress } from "@tonconnect/ui-react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useTonAddress, useTonConnectUI } from "@tonconnect/ui-react";
 import { ensureWalletBound } from "../utils/walletBind";
 
-const WalletContext = createContext({ wallet: null, setWallet: () => {} });
+// Context now also exposes a `disconnect` helper and potential error state.
+const WalletContext = createContext({
+  wallet: null,
+  setWallet: () => {},
+  disconnect: () => {},
+  error: null,
+});
 export const useWallet = () => useContext(WalletContext);
 
 export default function WalletProvider({ children }) {
   const [wallet, setWallet] = useState(() => localStorage.getItem("walletAddress") || null);
   const tonWallet = useTonAddress();
+  const [tonConnectUI] = useTonConnectUI();
+  const [error, setError] = useState(null);
 
   // keep localStorage in sync
   useEffect(() => {
@@ -25,11 +39,31 @@ export default function WalletProvider({ children }) {
 
   // bind wallet to backend session
   useEffect(() => {
-    ensureWalletBound(wallet);
+    if (!wallet) return;
+    ensureWalletBound(wallet).catch((e) => {
+      console.error("[WalletContext] bind error", e);
+      setError(e?.message || "Failed to bind wallet");
+    });
   }, [wallet]);
 
+  const disconnect = async () => {
+    try {
+      await tonConnectUI.disconnect();
+    } catch (e) {
+      console.error("[WalletContext] disconnect error", e);
+      setError(e?.message || "Failed to disconnect");
+    }
+    setWallet(null);
+    localStorage.removeItem("walletAddress");
+    localStorage.removeItem("wallet");
+    window.dispatchEvent(new CustomEvent("wallet:changed", { detail: { wallet: "" } }));
+  };
+
   // also read any TON address that other code may have saved
-  const value = useMemo(() => ({ wallet, setWallet }), [wallet]);
+  const value = useMemo(
+    () => ({ wallet, setWallet, disconnect, error, setError }),
+    [wallet, error]
+  );
 
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- add reusable `WalletConnect` component powered by TonConnect v2
- surface disconnect helper in wallet context
- update sidebar to display wallet connect/disconnect button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcd1ac523c832bbfb71eb57ef9a944