### PR TITLE
feat: make wallet hook reactive

### DIFF
--- a/src/hooks/useWallet.js
+++ b/src/hooks/useWallet.js
@@ -1,4 +1,21 @@
+import { useEffect, useState } from 'react';
+
 export function useWallet() {
-  const wallet = localStorage.getItem('wallet');
+  const [wallet, setWallet] = useState(() => localStorage.getItem('wallet'));
+
+  useEffect(() => {
+    const updateWallet = () => {
+      setWallet(localStorage.getItem('wallet'));
+    };
+
+    window.addEventListener('wallet:changed', updateWallet);
+    window.addEventListener('storage', updateWallet);
+
+    return () => {
+      window.removeEventListener('wallet:changed', updateWallet);
+      window.removeEventListener('storage', updateWallet);
+    };
+  }, []);
+
   return { wallet };
 }


### PR DESCRIPTION
## Summary
- use `useState` and `useEffect` in `useWallet`
- update wallet state on `wallet:changed` and `storage` events

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd8561170832b8e6710b9d0ea1e78