### PR TITLE
refactor: use TextEncoder for utf8 base64

### DIFF
--- a/src/components/ConnectButtons.js
+++ b/src/components/ConnectButtons.js
@@ -5,7 +5,12 @@ import { getSavedWallet } from "../utils/wallet";
 
 export default function ConnectButtons({ onLinked }) {
   const go = (url) => (window.location.href = url);
-  const b64 = (s) => window.btoa(unescape(encodeURIComponent(s || "")));
+  const b64 = (s) => {
+    const bytes = new TextEncoder().encode(s || "");
+    let binary = "";
+    bytes.forEach((b) => (binary += String.fromCharCode(b)));
+    return window.btoa(binary);
+  };
 
   async function connectTwitter() {
     const w = getSavedWallet();

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -31,7 +31,10 @@ const ConnectButtons = () => null;
 const stripAt = (h) => String(h || "").replace(/^@/, "");
 function b64(s) {
   try {
-    return window.btoa(unescape(encodeURIComponent(s || "")));
+    const bytes = new TextEncoder().encode(s || "");
+    let binary = "";
+    bytes.forEach((b) => (binary += String.fromCharCode(b)));
+    return window.btoa(binary);
   } catch {
     return "";
   }


### PR DESCRIPTION
## Summary
- replace deprecated `unescape(encodeURIComponent())` pattern with `TextEncoder`
- update profile and connect buttons to use TextEncoder-based base64 helper

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68bcd9319694832b88a2c7c6ef11b12e