### PR TITLE
validate quest proofs inputs

### DIFF
--- a/backend/src/routes/quests.js
+++ b/backend/src/routes/quests.js
@@ -20,6 +20,28 @@ function createRouter(db, { awardQuest, clearUserCache } = {}) {
   router.post('/:id/proofs', (req, res) => {
     const id = Number(req.params.id);
     const { wallet, vendor, url } = req.body || {};
+
+    if (typeof wallet !== 'string' || !wallet.trim()) {
+      return res.status(400).json({ error: 'wallet required' });
+    }
+    if (typeof vendor !== 'string' || !vendor.trim()) {
+      return res.status(400).json({ error: 'vendor required' });
+    }
+    if (typeof url !== 'string' || !url.trim()) {
+      return res.status(400).json({ error: 'url required' });
+    }
+
+    const allowedVendors = new Set(['twitter', 'telegram', 'discord', 'link']);
+    if (!allowedVendors.has(vendor)) {
+      return res.status(400).json({ error: 'unsupported vendor' });
+    }
+
+    try {
+      new URL(url);
+    } catch {
+      return res.status(400).json({ error: 'invalid url' });
+    }
+
     const quest = db.prepare('SELECT id FROM quests WHERE id = ?').get(id);
     if (!quest) return res.status(404).json({ error: 'Quest not found' });
     db.prepare('INSERT INTO quest_proofs (quest_id, wallet, vendor, url, updated_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)').run(id, wallet, vendor, url);

--- a/src/quests.api.test.js
+++ b/src/quests.api.test.js
@@ -62,9 +62,47 @@ describe('quests API', () => {
     app.use(express.json());
     app.use('/api/quests', createRouter(db));
     const res = await call(app, 'POST', '/api/quests/1/proofs', {
-      url: 'u',
+      wallet: 'w',
+      vendor: 'link',
+      url: 'https://example.com',
     });
     expect(res.status).toBe(200);
-    expect(proofs[0]).toEqual({ questId: 1, wallet: undefined, vendor: undefined, url: 'u' });
+    expect(proofs[0]).toEqual({ questId: 1, wallet: 'w', vendor: 'link', url: 'https://example.com' });
+  });
+
+  test('POST /api/quests/:id/proofs rejects invalid url', async () => {
+    const db = {
+      prepare: (sql) => ({
+        get: () => ({ id: 1 }),
+        run: () => {},
+      }),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use('/api/quests', createRouter(db));
+    const res = await call(app, 'POST', '/api/quests/1/proofs', {
+      wallet: 'w',
+      vendor: 'link',
+      url: 'not-a-url',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /api/quests/:id/proofs rejects unsupported vendor', async () => {
+    const db = {
+      prepare: (sql) => ({
+        get: () => ({ id: 1 }),
+        run: () => {},
+      }),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use('/api/quests', createRouter(db));
+    const res = await call(app, 'POST', '/api/quests/1/proofs', {
+      wallet: 'w',
+      vendor: 'myspace',
+      url: 'https://example.com',
+    });
+    expect(res.status).toBe(400);
   });
 });


### PR DESCRIPTION
## Summary
- validate presence and types of `wallet`, `vendor`, and `url` for quest proofs
- reject unsupported vendors and invalid URLs with 400 errors
- add tests covering success, invalid URL, and unsupported vendor cases

## Testing
- `npm test -- src/quests.api.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd26e64d50832b842f2abe6a7417ff