### PR TITLE
Add CORS middleware to backend

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const cors = require('cors');
 const { createRouter } = require('./src/routes/quests.js');
 const fs = require('fs');
 
@@ -6,6 +7,7 @@ const FRONTEND_URL = process.env.FRONTEND_URL || '';
 
 const app = express();
 app.set('etag', false);
+app.use(cors({ origin: FRONTEND_URL || false }));
 app.use(express.json());
 app.use('/api', (req, res, next) => {
   res.set('Cache-Control', 'no-store');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tonconnect/ui-react": "^2.2.0",
     "axios": "^1.11.0",
     "canvas-confetti": "^1.9.3",
+    "cors": "^2.8.5",
     "dayjs": "^1.11.13",
     "framer-motion": "^12.23.6",
     "qrcode.react": "^4.2.0",


### PR DESCRIPTION
## Summary
- install cors dependency
- apply middleware using `FRONTEND_URL` to restrict allowed origins

## Testing
- `CI=true npm test`
- `npm install cors` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27ecc718832b91c66cf17b3a4b1c