### PR TITLE
Fix profile defaults and /api/users/me handling

### DIFF
--- a/src/pages/Profile.css
+++ b/src/pages/Profile.css
@@ -266,3 +266,19 @@
     gap: 8px;
   }
 }
+
+/* Skeleton loader */
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(255,255,255,0.09), rgba(255,255,255,0.05));
+}
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.12), transparent);
+  animation: skShine 1.2s ease-in-out infinite;
+}
+@keyframes skShine { to { transform: translateX(100%); } }


### PR DESCRIPTION
## Summary
- add default profile response and session-based wallet binding on backend
- normalize `/api/users/me` results on frontend and show skeleton/connect states
- add skeleton styles for profile page

## Testing
- `npm test --silent`
- `node backend/server.js` *(fails: Cannot find module 'cors')*


------
https://chatgpt.com/codex/tasks/task_e_68bd2bbd0730832b8d30ecf6032d40fe