### PR TITLE
Add health endpoint, referral flow, and profile fallbacks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import {
   soundIsEnabled,
   attachGlobalClickSFX,
 } from "./utils/sounds";
+import { API_BASE } from "./utils/api";
 
 const manifestUrl = "/tonconnect-manifest.json";
 
@@ -30,6 +31,7 @@ const Profile      = lazy(() => import("./pages/Profile"));
 const Isles        = lazy(() => import("./pages/Isles"));
 const NotFound     = lazy(() => import("./pages/NotFound"));  // fallback route
 const TestAPI      = lazy(() => import("./pages/TestAPI"));   // connectivity check
+const RefRedirect  = lazy(() => import("./pages/RefRedirect"));
 
 /* -----------------------------
    Ambient background layers
@@ -74,6 +76,11 @@ const App = () => {
       window.removeEventListener("pointerdown", arm);
       window.removeEventListener("keydown", arm);
     };
+    const params = new URLSearchParams(window.location.search);
+    const ref = params.get('ref');
+    if (ref) {
+      window.location.href = `${API_BASE}/ref/${encodeURIComponent(ref)}`;
+    }
   }, []);
 
   return (
@@ -90,6 +97,7 @@ const App = () => {
                   <Route path="/quests" element={<Quests />} />
                   <Route path="/leaderboard" element={<Leaderboard />} />
                   <Route path="/referral" element={<Referral />} />
+                  <Route path="/ref/:code" element={<RefRedirect />} />
                   <Route path="/subscription" element={<Subscription />} />
                   <Route path="/token-sale" element={<TokenSale />} />
                   <Route path="/profile" element={<Profile />} />

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -30,19 +30,17 @@ const perksMap = {
 const ConnectButtons = () => null;
 
 const DEFAULT_ME = {
-  anon: true,
   wallet: null,
   xp: 0,
-  level: 1,
-  levelSymbol: "Shellborn",
+  level: "Shellborn",
+  levelName: "Shellborn",
+  levelSymbol: "🐚",
   nextXP: 100,
+  twitterHandle: null,
+  telegramId: null,
+  discordId: null,
   subscriptionTier: "Free",
-  socials: {
-    twitterHandle: null,
-    telegramId: null,
-    discordId: null,
-    discordGuildMember: false,
-  },
+  questHistory: [],
   referral_code: null,
 };
 
@@ -188,36 +186,33 @@ export default function Profile() {
   const applyProfile = useCallback(
     (meObj) => {
       setMe(meObj);
-      if (meObj.anon) {
+      if (!meObj || !meObj.wallet) {
         setHasProfile(false);
         return;
       }
       setXp(meObj.xp ?? 0);
       setTier(meObj.tier || meObj.subscriptionTier || "Free");
 
-      const lvlName = meObj.level || "Shellborn";
+      const lvlName = meObj.levelName || meObj.level || "Shellborn";
       setLevel({
         name: lvlName,
-        symbol: "🐚",
+        symbol: meObj.levelSymbol || "🐚",
         progress: meObj.levelProgress ?? 0,
-        nextXP: meObj.nextXP ?? 10000,
+        nextXP: meObj.nextXP ?? 100,
       });
       setPerk(perksMap[lvlName] || "");
 
-      const socials = meObj.socials || {};
-      setTwitter(
-        socials.twitter?.connected ? stripAt(socials.twitter.username) : ""
-      );
-      setTelegram(
-        socials.telegram?.connected ? stripAt(socials.telegram.username) : ""
-      );
-      setDiscord(
-        socials.discord?.connected ? String(socials.discord.username) : ""
-      );
+      setTwitter(stripAt(meObj.twitterHandle));
+      setTelegram(stripAt(meObj.telegramId));
+      setDiscord(stripAt(meObj.discordId));
       setDiscordGuildMember(false);
-      setReferralCode(meObj.referral_code || meObj.referralCode || '');
+      setReferralCode(meObj.referral_code || meObj.referralCode || "");
 
-      const hist = Array.isArray(meObj?.history) ? meObj.history : [];
+      const hist = Array.isArray(meObj.questHistory)
+        ? meObj.questHistory
+        : Array.isArray(meObj.history)
+        ? meObj.history
+        : [];
       setHistory(hist);
 
       if (meObj.wallet && !address) setAddress(meObj.wallet);
@@ -234,7 +229,6 @@ export default function Profile() {
       const merged = {
         ...DEFAULT_ME,
         ...(apiMe || {}),
-        socials: { ...DEFAULT_ME.socials, ...(apiMe?.socials || {}) },
       };
       applyProfile(merged);
     } catch (e) {
@@ -389,7 +383,7 @@ export default function Profile() {
 
       {loading ? (
         <div className="skeleton" style={{ height: 160, borderRadius: 16 }} />
-      ) : me.anon || !address || !hasProfile ? (
+      ) : !address || !hasProfile ? (
         <div style={{ textAlign: 'center' }}>
           <p>🔌 Connect your TON wallet to view your profile.</p>
           <WalletConnect />

--- a/src/pages/RefRedirect.js
+++ b/src/pages/RefRedirect.js
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { API_BASE } from "../utils/api";
+
+export default function RefRedirect() {
+  const { code } = useParams();
+  useEffect(() => {
+    if (code) {
+      window.location.href = `${API_BASE}/ref/${encodeURIComponent(code)}`;
+    }
+  }, [code]);
+  return <div className="section">Setting referral cookie…</div>;
+}

--- a/src/pages/TestAPI.js
+++ b/src/pages/TestAPI.js
@@ -1,11 +1,17 @@
 import React, { useState } from "react";
-import { api, getQuests, getLeaderboard, getMe } from "../utils/api";
+import { api, getQuests, getLeaderboard, getMe, getJSON } from "../utils/api";
 export default function TestAPI() {
   const [log, setLog] = useState([]);
   const add = (s) => setLog((x) => [...x, s]);
   async function run() {
     setLog([]);
     add(`API_BASE = ${api.base || "(same-origin)"}`);
+    try {
+      const h = await getJSON("/api/health");
+      add(`✓ /api/health OK (${Math.round(h.uptime)}s)`);
+    } catch (e) {
+      add(`✗ /api/health: ${e.message}`);
+    }
     try {
       const q = await getQuests();
       add(`✓ /api/quests OK (${(q?.quests || []).length})`);
@@ -20,11 +26,10 @@ export default function TestAPI() {
     }
     try {
       const me = await getMe();
-      const s = me.socials || {};
       const summary = [
-        `telegram=${s.telegram?.connected ? s.telegram.username : "off"}`,
-        `twitter=${s.twitter?.connected ? s.twitter.username : "off"}`,
-        `discord=${s.discord?.connected ? s.discord.username : "off"}`,
+        `telegram=${me.telegramId || 'off'}`,
+        `twitter=${me.twitterHandle || 'off'}`,
+        `discord=${me.discordId || 'off'}`,
       ].join(", ");
       add(`✓ /api/users/me: ${summary}`);
     } catch (e) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -208,6 +208,10 @@ export function getReferralsList(opts = {}) {
   return getJSON("/api/referral/list", opts);
 }
 
+export function getReferralStatus(opts = {}) {
+  return getJSON("/api/referral/status", opts);
+}
+
 export const api = {
   base: API_BASE,
   getQuests,
@@ -225,6 +229,7 @@ export const api = {
   createReferral,
   applyReferral,
   getReferralsList,
+  getReferralStatus,
   postJSON,
   get: getJSON,
   getJSON,


### PR DESCRIPTION
## Summary
- expose `/api/health` and harden `/api/users/me` with safe defaults
- support referral tracking via `/ref/:code`, wallet bind crediting, and `/api/referral/status`
- frontend: handle `?ref=`/`/ref/:code` redirects and resilient profile rendering

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bd35065b34832bbaf4bed4dd0478cb