### PR TITLE
Use shared ConnectButtons component on profile page

### DIFF
--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -3,10 +3,12 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTonAddress } from "@tonconnect/ui-react";
 import "./Profile.css";
 import "../App.css";
+import "../components/ConnectButtons.css";
 import { API_BASE, API_URLS, fetchJson } from "../utils/api";
 import { ensureWalletBound } from "../utils/walletBind";
 import { unlinkSocial, resyncSocial } from "../utils/socialLinks"; // ✅ RIGHT IMPORT
 import WalletConnect from "../components/WalletConnect";
+import ConnectButtons from "../components/ConnectButtons.jsx";
 
 // Optional: invite link shown if user linked Discord but isn't in the server
 const DISCORD_INVITE = process.env.REACT_APP_DISCORD_INVITE || "";
@@ -26,8 +28,6 @@ const perksMap = {
   "Cowrie Ascendant": "Unlock hidden realm + max power 🐚✨",
 };
 
-// Keep placeholder to preserve layout; we now use explicit buttons below
-const ConnectButtons = () => null;
 
 const DEFAULT_ME = {
   wallet: null,
@@ -614,31 +614,7 @@ export default function Profile() {
             <h3>Link New Accounts</h3>
             <p className="muted">Link your socials to unlock quests and show badges.</p>
 
-            <ConnectButtons onLinked={() => loadMe()} />
-
-            <div className="connect-buttons" style={{ marginTop: 12 }}>
-              <button
-                className="connect-btn"
-                onClick={connectTwitter}
-                disabled={connecting.twitter || !!twitter}
-              >
-                {twitter ? '✅ X (Twitter)' : '🐦 Connect X (Twitter)'}
-              </button>
-              <button
-                className="connect-btn"
-                onClick={connectTelegram}
-                disabled={connecting.telegram || !!telegram}
-              >
-                {telegram ? '✅ Telegram' : '📣 Connect Telegram'}
-              </button>
-              <button
-                className="connect-btn"
-                onClick={connectDiscord}
-                disabled={connecting.discord || !!discord}
-              >
-                {discord ? '✅ Discord' : '🎮 Connect Discord'}
-              </button>
-            </div>
+            <ConnectButtons address={address} />
 
             {/* Embedded Telegram button (preferred) */}
             <p className="muted" style={{ marginTop: 8 }}>


### PR DESCRIPTION
## Summary
- Import shared ConnectButtons component and CSS in profile page
- Replace placeholder and redundant manual connect buttons with `<ConnectButtons address={address} />`

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bddc238044832b9260794cbbb456e9