### PR TITLE
feat: improve api error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,8 @@ TonConnect manifest is served from the same origin at `/tonconnect-manifest.json
 The frontend talks to the backend REST API:
 
 - `GET /api/users/:wallet` – fetch profile (`xp`, `levelName`, `progress`)
-- `POST /api/quests/claim` – claim quest; returns `{ alreadyClaimed: boolean }`
+- `POST /api/quests/:id/claim` – claim quest; returns `{ alreadyClaimed: boolean }`
 - `GET /api/meta/progression` – XP progression metadata
-
-### Deprecation
-
-Legacy endpoints `/quests` and `/complete` are deprecated and will be removed after launch. Use `/api/quests` and `/api/quests/claim` instead.
 
 ## Vercel
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,18 +1,64 @@
 const API_URL = process.env.REACT_APP_API_URL;
 
+if (!API_URL) {
+  throw new Error(
+    'REACT_APP_API_URL is required – set it in your environment or .env file'
+  );
+}
+
 export async function apiGet(endpoint) {
-  const res = await fetch(`${API_URL}${endpoint}`, {
-    credentials: 'include', // important if using cookies/sessions
-  });
+  let res;
+  try {
+    res = await fetch(`${API_URL}${endpoint}`, {
+      credentials: 'include', // important if using cookies/sessions
+    });
+  } catch (err) {
+    const msg = `Network error: ${err.message}`;
+    if (typeof window !== 'undefined' && window.alert) {
+      window.alert(msg);
+    }
+    throw new Error(msg);
+  }
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`;
+    try {
+      const data = await res.json();
+      msg += data?.error ? `: ${data.error}` : '';
+    } catch (_) {}
+    if (typeof window !== 'undefined' && window.alert) {
+      window.alert(msg);
+    }
+    throw new Error(msg);
+  }
   return res.json();
 }
 
 export async function apiPost(endpoint, body) {
-  const res = await fetch(`${API_URL}${endpoint}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify(body),
-  });
+  let res;
+  try {
+    res = await fetch(`${API_URL}${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const msg = `Network error: ${err.message}`;
+    if (typeof window !== 'undefined' && window.alert) {
+      window.alert(msg);
+    }
+    throw new Error(msg);
+  }
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`;
+    try {
+      const data = await res.json();
+      msg += data?.error ? `: ${data.error}` : '';
+    } catch (_) {}
+    if (typeof window !== 'undefined' && window.alert) {
+      window.alert(msg);
+    }
+    throw new Error(msg);
+  }
   return res.json();
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -3,6 +3,18 @@ export const API_BASE =
   process.env.REACT_APP_API_URL ||
   "";
 
+// Ensure the API base URL is configured. This avoids accidentally
+// pointing requests at the current origin which can be confusing in
+// development and misconfigured in production.  The value should be
+// supplied via `REACT_APP_API_URL` or injected into `window.__API_BASE`.
+// Throwing here makes the failure obvious during start‑up rather than at
+// the first network request.
+if (!API_BASE) {
+  throw new Error(
+    "REACT_APP_API_URL is required – set it in your environment or .env file"
+  );
+}
+
 // Prebuilt URLs for starting OAuth or embedding auth widgets
 export const API_URLS = {
   twitterStart: `${API_BASE}/auth/twitter`,
@@ -29,7 +41,11 @@ export async function fetchJson(url, options = {}) {
       ...(options || {}),
     });
   } catch (err) {
-    throw new Error(`Network error: ${err.message}`);
+    const msg = `Network error: ${err.message}`;
+    if (typeof window !== "undefined" && window.alert) {
+      window.alert(msg);
+    }
+    throw new Error(msg);
   }
 
   if (res.status === 304) return null;
@@ -47,6 +63,9 @@ export async function fetchJson(url, options = {}) {
       } catch (_) {
         /* ignore */
       }
+    }
+    if (typeof window !== "undefined" && window.alert) {
+      window.alert(msg);
     }
     throw new Error(msg);
   }


### PR DESCRIPTION
## Summary
- require REACT_APP_API_URL on startup to avoid misconfigured requests
- surface fetch errors to users with alert messages
- remove documentation for deprecated /quests and /complete endpoints

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bdeaaf62b0832b94867b16783e7ab0