### PR TITLE
Quests proof+claim, profile socials, referrals, healthcheck

### DIFF
--- a/src/components/ProfileWidget.js
+++ b/src/components/ProfileWidget.js
@@ -26,9 +26,9 @@ export default function ProfileWidget() {
     return () => window.removeEventListener('profile-updated', onUpdate);
   }, []);
 
-  if (loading) return <div>Loading profile...</div>;
+  if (loading) return <div style={{ height: 40 }} />;
   if (error) return <div>Error: {error}</div>;
-  if (!me) return null;
+  if (!me) return <div style={{ height: 40 }} />;
 
   const progressPct = clampProgress((me.levelProgress || 0) * 100);
 

--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -1,18 +1,8 @@
 import React from 'react';
 
-// Quests that require an external proof before claiming. These map to the
-// `requirement` field returned by the backend API. Earlier versions of the app
-// used more granular requirement names (e.g. `twitter_follow`), but the new
-// contract standardises on these generic values.
-const NEEDS_PROOF = new Set([
-  'tweet_link',
-  'join_telegram',
-  'join_discord',
-]);
-
 export default function QuestCard({ quest, onClaim, onProof, claiming }) {
   const q = quest;
-  const needsProof = NEEDS_PROOF.has(q.requirement);
+  const needsProof = q.requirement && q.requirement !== 'none';
   const alreadyClaimed = q.completed || q.alreadyClaimed || q.claimed;
   const claimable = !alreadyClaimed && (!needsProof || q.proofStatus === 'approved');
   return (
@@ -38,13 +28,11 @@ export default function QuestCard({ quest, onClaim, onProof, claiming }) {
           </span>
         )}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          {alreadyClaimed ? (
-            <span className="chip completed">Completed</span>
-          ) : typeof q.proofStatus === 'string' ? (
-            <span className={`chip ${q.proofStatus}`}>
-              {q.proofStatus.charAt(0).toUpperCase() + q.proofStatus.slice(1)}
-            </span>
-          ) : null}
+        {alreadyClaimed ? (
+          <span className="chip completed">✅ Completed</span>
+        ) : q.proofStatus === 'pending' ? (
+          <span className="chip pending">🕒 Pending review</span>
+        ) : null}
           <span className="xp-badge">+{q.xp} XP</span>
         </div>
       </div>
@@ -106,6 +94,7 @@ export default function QuestCard({ quest, onClaim, onProof, claiming }) {
             className="btn ghost"
             onClick={() => onClaim(q.id)}
             disabled={claiming || !claimable}
+            title={!claimable && needsProof ? 'Submit proof first' : ''}
           >
             {claiming ? 'Claiming...' : 'Claim'}
           </button>

--- a/src/components/SubmitProofModal.js
+++ b/src/components/SubmitProofModal.js
@@ -1,15 +1,18 @@
 import React, { useState } from 'react';
 import { submitProof } from '../utils/api';
-import { parseTweetId, isValidTweetUrl } from '../utils/validators';
+import { isValidTweetUrl } from '../utils/validators';
 
 export default function SubmitProofModal({ quest, onClose, onSuccess, onError }) {
   const [url, setUrl] = useState('');
   const vendor = (() => {
     switch (quest?.requirement) {
+      case 'tweet':
       case 'tweet_link':
         return 'twitter';
+      case 'telegram':
       case 'join_telegram':
         return 'telegram';
+      case 'discord':
       case 'join_discord':
         return 'discord';
       default:
@@ -39,12 +42,8 @@ export default function SubmitProofModal({ quest, onClose, onSuccess, onError })
     }
     setSubmitting(true);
     try {
-      const body = { url, vendor };
-      if (vendor === 'twitter') {
-        body.tweet_id = parseTweetId(url);
-      }
-      const res = await submitProof(quest.id, body);
-      onSuccess && onSuccess(res.proof);
+      const res = await submitProof(quest.id, { url });
+      onSuccess && onSuccess(res);
       onClose();
     } catch (e) {
       const message = e.message || 'Failed to submit proof';

--- a/src/context/WalletContext.js
+++ b/src/context/WalletContext.js
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { useTonAddress, useTonConnectUI } from "@tonconnect/ui-react";
 import { ensureWalletBound } from "../utils/walletBind";
+import { emitWalletChanged } from "../utils/events";
 
 // Context now also exposes a `disconnect` helper and potential error state.
 const WalletContext = createContext({
@@ -28,7 +29,7 @@ export default function WalletProvider({ children }) {
     if (wallet) {
       localStorage.setItem("walletAddress", wallet);
       localStorage.setItem("wallet", wallet);
-      window.dispatchEvent(new CustomEvent('wallet:changed', { detail: { wallet } }));
+      emitWalletChanged(wallet);
     }
   }, [wallet]);
 
@@ -56,7 +57,7 @@ export default function WalletProvider({ children }) {
     setWallet(null);
     localStorage.removeItem("walletAddress");
     localStorage.removeItem("wallet");
-    window.dispatchEvent(new CustomEvent("wallet:changed", { detail: { wallet: "" } }));
+    emitWalletChanged("");
   };
 
   // also read any TON address that other code may have saved

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import App from "./App";
 import { TonConnectUIProvider } from "@tonconnect/ui-react";
 import WalletProvider from "./context/WalletContext";
 import './styles/polish.css';
+import { setupWalletSync } from './utils/init';
 
 // Prefer an env override; otherwise use the local manifest served from /public
 const manifestUrl =
@@ -12,6 +13,8 @@ const manifestUrl =
   `${window.location.origin}/tonconnect-manifest.json`;
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
+
+setupWalletSync();
 
 root.render(
   <React.StrictMode>

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -9,7 +9,6 @@ import '../App.css';
 
 export default function Quests() {
   const [quests, setQuests] = useState([]);
-  const [completed, setCompleted] = useState([]);
   const [xp, setXp] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -32,7 +31,6 @@ export default function Quests() {
     const data = await getQuests({ signal });
     if (!mountedRef.current) return;
     setQuests(data?.quests ?? []);
-    setCompleted(data?.completed ?? []);
     setXp(data?.xp ?? 0);
   }
 
@@ -103,7 +101,6 @@ export default function Quests() {
       if (mountedRef.current) {
         setMe(meData);
         setQuests(questsData?.quests ?? []);
-        setCompleted(questsData?.completed ?? []);
         setXp(questsData?.xp ?? 0);
       }
       window.dispatchEvent(new Event('profile-updated'));
@@ -128,15 +125,15 @@ export default function Quests() {
     setProofQuest(q);
   };
 
-  const onProofSubmitted = (proof) => {
+  const onProofSubmitted = (res) => {
     if (process.env.NODE_ENV !== 'production') {
-      console.log('proof_submitted', proofQuest?.id, proof?.status);
+      console.log('proof_submitted', proofQuest?.id, res?.status);
     }
     setToast('Proof submitted');
     setQuests((qs) =>
       qs.map((qq) =>
-        qq.id === (proofQuest?.id || proof?.quest_id)
-          ? { ...qq, proofStatus: proof?.status || 'pending' }
+        qq.id === proofQuest?.id
+          ? { ...qq, proofStatus: res?.status || 'pending' }
           : qq
       )
     );

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -165,8 +165,9 @@ export async function getMe({ signal } = {}) {
   const cached = cacheGet(key);
   if (cached) return Promise.resolve(cached);
   return jsonFetch("/api/users/me", { signal }).then((data) => {
-    if (data) cacheSet(key, data);
-    return data;
+    const user = data && typeof data === 'object' && 'user' in data ? data.user : data;
+    if (user) cacheSet(key, user);
+    return user;
   });
 }
 

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,0 +1,7 @@
+export function emitWalletChanged(wallet) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('wallet:changed', { detail: { wallet } })
+    );
+  }
+}

--- a/src/utils/init.js
+++ b/src/utils/init.js
@@ -1,0 +1,25 @@
+import { ensureWalletBound } from './walletBind';
+import { getMe, getQuests } from './api';
+
+export function setupWalletSync() {
+  async function sync() {
+    const w = typeof localStorage !== 'undefined' ? localStorage.getItem('wallet') : null;
+    if (w) {
+      try {
+        await ensureWalletBound(w);
+      } catch (e) {
+        console.error('[init] bind failed', e);
+      }
+    }
+    try {
+      await Promise.all([getMe(), getQuests()]);
+    } catch (e) {
+      console.error('[init] preload failed', e);
+    }
+  }
+
+  sync();
+  if (typeof window !== 'undefined') {
+    window.addEventListener('wallet:changed', sync);
+  }
+}


### PR DESCRIPTION
## Summary
- dispatch `wallet:changed` via helper and sync profile/quests on wallet events
- handle {user:null} and referral links; render social connection status
- update quest cards and proof modal for link/tweet requirements with tooltips

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68be097171a0832ba5213e84e0d899fe