### PR TITLE
Normalize API responses and sync wallet

### DIFF
--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -15,11 +15,16 @@ const lore = {
 const Leaderboard = () => {
   const [leaders, setLeaders] = useState([]);
   const [error, setError] = useState('');
+  const [total, setTotal] = useState(0);
 
   useEffect(() => {
     let mounted = true;
     getLeaderboard()
-      .then((data) => mounted && setLeaders(data.top || []))
+      .then((data) => {
+        if (!mounted) return;
+        setLeaders(data.entries || []);
+        setTotal(data.total || 0);
+      })
       .catch((e) => {
         if (mounted) setError(e.message || 'Failed to load leaderboard');
       });
@@ -40,7 +45,12 @@ const Leaderboard = () => {
       ) : (
         <div className="leaderboard-list">
           {leaders.map((user, i) => (
-            <div key={user.wallet} className={`leader-card ${i === 0 ? 'gold' : i === 1 ? 'silver' : i === 2 ? 'bronze' : ''}`}>
+            <div
+              key={user.wallet}
+              className={`leader-card ${
+                i === 0 ? 'gold' : i === 1 ? 'silver' : i === 2 ? 'bronze' : ''
+              } ${user.wallet === currentWallet ? 'you' : ''}`}
+            >
               <div className="rank-badge">#{user.rank}</div>
               <div className="user-info">
                 <img
@@ -50,11 +60,11 @@ const Leaderboard = () => {
                   className="user-badge"
                 />
                 <div className="user-meta">
-                  <p><strong>{shorten(user.wallet)}</strong> {user.twitter && <span> | 🐦 @{user.twitter}</span>}</p>
+                  <p><strong>{shorten(user.wallet)}</strong> {user.twitterHandle && <span> | 🐦 @{user.twitterHandle}</span>}</p>
                   <p>{user.tier} • {user.name}</p>
                   <div className="progress-container">
                     <div className="progress-bar">
-                      <div className="progress-fill" style={{ width: `${user.progress.toFixed(1)}%` }}></div>
+                      <div className="progress-fill" style={{ width: `${(user.progress || 0) * 100}%` }}></div>
                     </div>
                     <small>{user.xp} XP — {lore[user.name]}</small>
                   </div>
@@ -68,8 +78,10 @@ const Leaderboard = () => {
   );
 };
 
-function shorten(addr) {
+function shorten(addr = '') {
   return addr.slice(0, 6) + '...' + addr.slice(-4);
 }
+
+const currentWallet = typeof localStorage !== 'undefined' ? localStorage.getItem('wallet') : null;
 
 export default Leaderboard;

--- a/src/components/SubmitProofModal.js
+++ b/src/components/SubmitProofModal.js
@@ -7,12 +7,12 @@ export default function SubmitProofModal({ quest, onClose, onSuccess, onError })
   const vendor = (() => {
     switch (quest?.requirement) {
       case 'tweet':
+      case 'retweet':
+      case 'quote':
       case 'tweet_link':
         return 'twitter';
-      case 'telegram':
       case 'join_telegram':
         return 'telegram';
-      case 'discord':
       case 'join_discord':
         return 'discord';
       default:
@@ -25,9 +25,9 @@ export default function SubmitProofModal({ quest, onClose, onSuccess, onError })
   if (!quest) return null;
 
   const placeholders = {
-    twitter: 'Paste tweet link',
-    telegram: 'Paste Telegram post link',
-    discord: 'Paste Discord message link',
+    twitter: 'Paste tweet/retweet/quote link',
+    telegram: 'Paste Telegram message/channel link',
+    discord: 'Paste Discord invite/message link',
     link: 'Paste link here',
   };
 

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -125,7 +125,7 @@ export default function Quests() {
     setProofQuest(q);
   };
 
-  const onProofSubmitted = (res) => {
+  const onProofSubmitted = async (res) => {
     if (process.env.NODE_ENV !== 'production') {
       console.log('proof_submitted', proofQuest?.id, res?.status);
     }
@@ -137,8 +137,15 @@ export default function Quests() {
           : qq
       )
     );
+    try {
+      const [meData, questsData] = await Promise.all([getMe(), getQuests()]);
+      if (mountedRef.current) {
+        setMe(meData);
+        setQuests(questsData?.quests ?? []);
+        setXp(questsData?.xp ?? 0);
+      }
+    } catch {}
     setTimeout(() => setToast(''), 3000);
-    sync();
     window.dispatchEvent(new Event('profile-updated'));
   };
 

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -98,7 +98,7 @@ describe('Quests page claiming', () => {
     const proofBtn = await screen.findByText('Submit proof');
     await userEvent.click(proofBtn);
 
-    const input = screen.getByPlaceholderText('Paste tweet link');
+    const input = screen.getByPlaceholderText('Paste tweet/retweet/quote link');
     await userEvent.type(input, 'https://twitter.com/user/status/1');
 
     submitProof.mockResolvedValueOnce({ ok: true, proof: { status: 'approved' } });

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -178,6 +178,9 @@ export async function postJSON(path, body, opts = {}) {
 export function claimQuest(id, opts = {}) {
   return postJSON(`/api/quests/${id}/claim`, {}, opts).then((res) => {
     clearUserCache();
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('profile-updated'));
+    }
     return res;
   });
 }
@@ -185,6 +188,9 @@ export function claimQuest(id, opts = {}) {
 export function submitProof(id, body, opts = {}) {
   return postJSON(`/api/quests/${id}/proofs`, body, opts).then((res) => {
     clearUserCache();
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('profile-updated'));
+    }
     return res;
   });
 }

--- a/src/utils/init.js
+++ b/src/utils/init.js
@@ -1,12 +1,13 @@
-import { ensureWalletBound } from './walletBind';
-import { getMe, getQuests } from './api';
+import { bindWallet, getMe, getQuests } from './api';
 
 export function setupWalletSync() {
   async function sync() {
-    const w = typeof localStorage !== 'undefined' ? localStorage.getItem('wallet') : null;
+    const ls = typeof localStorage !== 'undefined' ? localStorage.getItem('wallet') : null;
+    const tc = typeof window !== 'undefined' && window.tonconnect?.account?.address;
+    const w = ls || tc || null;
     if (w) {
       try {
-        await ensureWalletBound(w);
+        await bindWallet(w);
       } catch (e) {
         console.error('[init] bind failed', e);
       }


### PR DESCRIPTION
## Summary
- dispatch `profile-updated` when claiming quests or submitting proof and return normalized profile data
- bootstrap app by binding wallet and preloading profile + quests on wallet changes
- handle proof submission and canonical referral links across quests, referral page, and leaderboard

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68be3c74e1b0832b97e911bcff0d9433