### PR TITLE
fix: correct tier XP multipliers

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -198,8 +198,9 @@ export function submitProof(id, body, opts = {}) {
 // UI-only helper for showing projected XP; backend still awards the truth.
 export function tierMultiplier(tier) {
   const t = String(tier || '').toLowerCase();
-  if (t.includes('tier 3')) return 1.25;
-  if (t.includes('tier 2')) return 1.10;
+  if (t.includes('tier 3')) return 1.5;
+  if (t.includes('tier 2')) return 1.25;
+  if (t.includes('tier 1')) return 1.10;
   return 1.0; // Free or unknown
 }
 


### PR DESCRIPTION
## Summary
- map subscription tiers to 1.10, 1.25, and 1.5 XP multipliers

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68be4ff1924c832baa960b6226ffcd08