### PR TITLE
Fix leaderboard data flow and profile socials

### DIFF
--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -54,24 +54,22 @@ const Leaderboard = () => {
               <div className="rank-badge">#{user.rank}</div>
               <div className="user-info">
                 <img
-                  src={`/images/badges/level-${user.name.toLowerCase().replace(/\s+/g, '-')}.png`}
-                  alt={user.name}
+                  src={`/images/badges/level-${(user.levelName || 'unranked').toLowerCase().replace(/\s+/g, '-')}.png`}
+                  alt={user.levelName || 'Unranked'}
                   onError={(e) => (e.target.src = '/images/badges/unranked.png')}
                   className="user-badge"
                 />
                 <div className="user-meta">
                   <p>
                     <strong>{shorten(user.wallet)}</strong>
-                    {user.twitterHandle && (
-                      <span> | 🐦 @{user.twitterHandle}</span>
-                    )}
+                    {user.twitterHandle ? <span> | 🐦 @{user.twitterHandle}</span> : null}
                   </p>
-                  <p>{user.tier} • {user.name}</p>
+                  <p>{user.tier} • {user.levelName}</p>
                   <div className="progress-container">
                     <div className="progress-bar">
                       <div className="progress-fill" style={{ width: `${((user.progress || 0) * 100).toFixed(1)}%` }} />
                     </div>
-                    <small>{user.xp} XP — {lore[user.name]}</small>
+                    <small>{user.xp} XP — {lore[user.levelName] || ''}</small>
                   </div>
                 </div>
               </div>

--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -53,23 +53,29 @@ const Leaderboard = () => {
             >
               <div className="rank-badge">#{user.rank}</div>
               <div className="user-info">
-                <img
-                  src={`/images/badges/level-${(user.levelName || 'unranked').toLowerCase().replace(/\s+/g, '-')}.png`}
-                  alt={user.levelName || 'Unranked'}
-                  onError={(e) => (e.target.src = '/images/badges/unranked.png')}
-                  className="user-badge"
-                />
+                {(() => {
+                  const lvl = (user.levelName || user.name || 'Shellborn');
+                  const slug = lvl.toLowerCase().replace(/\s+/g, '-');
+                  return (
+                    <img
+                      src={`/images/badges/level-${slug}.png`}
+                      alt={lvl}
+                      onError={(e) => (e.target.src = '/images/badges/unranked.png')}
+                      className="user-badge"
+                    />
+                  );
+                })()}
                 <div className="user-meta">
                   <p>
                     <strong>{shorten(user.wallet)}</strong>
                     {user.twitterHandle ? <span> | 🐦 @{user.twitterHandle}</span> : null}
                   </p>
-                  <p>{user.tier} • {user.levelName}</p>
+                  <p>{user.tier} • {user.levelName || 'Shellborn'}</p>
                   <div className="progress-container">
                     <div className="progress-bar">
                       <div className="progress-fill" style={{ width: `${((user.progress || 0) * 100).toFixed(1)}%` }} />
                     </div>
-                    <small>{user.xp} XP — {lore[user.levelName] || ''}</small>
+                    <small>{user.xp} XP — {lore[user.levelName || 'Shellborn']}</small>
                   </div>
                 </div>
               </div>

--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -22,8 +22,8 @@ const Leaderboard = () => {
     getLeaderboard()
       .then((data) => {
         if (!mounted) return;
-        setLeaders(data.entries || []);
-        setTotal(data.total || 0);
+        setLeaders(Array.isArray(data?.entries) ? data.entries : []);
+        setTotal(Number(data?.total ?? 0));
       })
       .catch((e) => {
         if (mounted) setError(e.message || 'Failed to load leaderboard');
@@ -69,7 +69,7 @@ const Leaderboard = () => {
                   <p>{user.tier} • {user.name}</p>
                   <div className="progress-container">
                     <div className="progress-bar">
-                      <div className="progress-fill" style={{ width: `${(user.progress || 0) * 100}%` }}></div>
+                      <div className="progress-fill" style={{ width: `${((user.progress || 0) * 100).toFixed(1)}%` }} />
                     </div>
                     <small>{user.xp} XP — {lore[user.name]}</small>
                   </div>

--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -33,16 +33,20 @@ export default function QuestCard({ quest, onClaim, onProof, claiming, me }) {
             {q.type.charAt(0).toUpperCase() + q.type.slice(1)}
           </span>
         ) : null}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          {alreadyClaimed ? (
-            <span className="chip completed">✅ Completed</span>
-          ) : q.proofStatus === 'pending' ? (
-            <span className="chip pending">🕒 Pending review</span>
-          ) : null}
-          <span className="xp-badge">
-            +{q.xp} XP{mult > 1 ? <span className="muted" style={{ marginLeft: 6 }}>(×{mult.toFixed(2)} ≈ {projected})</span> : null}
-          </span>
-        </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            {alreadyClaimed ? (
+              <span className="chip completed">✅ Completed</span>
+            ) : q.proofStatus === 'pending' ? (
+              <span className="chip pending">🕒 Pending review</span>
+            ) : null}
+            <span className="xp-badge">
+              +{q.xp} XP{mult > 1 ? (
+                <span className="muted" style={{ marginLeft: 6 }}>
+                  (×{mult.toFixed(2)} ≈ {projected})
+                </span>
+              ) : null}
+            </span>
+          </div>
       </div>
       <p className="quest-title">
         {q.url ? (

--- a/src/pages/Leaderboard.js
+++ b/src/pages/Leaderboard.js
@@ -16,16 +16,10 @@ export default function Leaderboard() {
     try {
       const data = await getLeaderboard({ signal });
       if (!mountedRef.current) return;
-      const raw = data?.leaders ?? data ?? [];
-      const list = Array.isArray(raw) ? raw : Array.isArray(raw.data) ? raw.data : [];
+      const list = Array.isArray(data?.entries) ? data.entries : [];
       const rows = list.map((u) => ({
         ...u,
-        progress: (() => {
-          const p = Number(u.levelProgress ?? u.progress ?? 0);
-          const pct = p <= 1 ? p * 100 : p;
-          const clamped = Math.max(0, Math.min(100, pct));
-          return clamped;
-        })(),
+        progress: Math.max(0, Math.min(1, Number(u.progress ?? u.levelProgress ?? 0))),
       }));
       setLeaders(rows);
       setError(null);
@@ -63,7 +57,7 @@ export default function Leaderboard() {
 
   const Bar = ({ pct = 0 }) => (
     <div className="bar-outer">
-      <div className="bar-inner" style={{ width: `${pct}%` }} />
+      <div className="bar-inner" style={{ width: `${(pct * 100).toFixed(1)}%` }} />
     </div>
   );
 
@@ -79,7 +73,12 @@ export default function Leaderboard() {
         {podium.map((u, i) => (
           <div key={u.wallet || i} className={`card glass podium-${i+1} ${walletRef.current===u.wallet ? 'me' : ''}`}>
             <div className="corner-rank">#{i+1}</div>
-            <div className="big-wallet">{abbreviateWallet(u.wallet)}</div>
+            <div className="big-wallet">
+              {abbreviateWallet(u.wallet)}
+              {u.twitterHandle ? (
+                <span className="muted" style={{ marginLeft: 6 }}>@{u.twitterHandle}</span>
+              ) : null}
+            </div>
             <div className="chips">
               <span className="chip">{u.tier || 'Free'}</span>
               <span className="chip">{u.levelName}</span>
@@ -101,7 +100,12 @@ export default function Leaderboard() {
             return (
               <div key={u.wallet || rank} className={`row glass ${isMe ? 'me' : ''}`}>
                 <div className="rank">#{rank}</div>
-                <div className="wallet mono">{abbreviateWallet(u.wallet)}</div>
+                <div className="wallet mono">
+                  {abbreviateWallet(u.wallet)}
+                  {u.twitterHandle ? (
+                    <span className="muted" style={{ marginLeft: 4 }}>@{u.twitterHandle}</span>
+                  ) : null}
+                </div>
                 <div className="badges">
                   <span className="chip">{u.tier || 'Free'}</span>
                   <span className="chip">{u.levelName}</span>

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -103,7 +103,6 @@ export default function Profile() {
   const [error, setError] = useState("");
   const [me, setMe] = useState(DEFAULT_ME);
 
-  const [xp, setXp] = useState(0);
   const [tier, setTier] = useState("Free");
   const [level, setLevel] = useState({
     name: "Shellborn",
@@ -112,14 +111,17 @@ export default function Profile() {
     nextXP: 10000,
   });
 
-  const [twitter, setTwitter] = useState("");
-  const [telegram, setTelegram] = useState("");
-  const [discord, setDiscord] = useState("");
-  const [twitterConnected, setTwitterConnected] = useState(false);
-  const [telegramConnected, setTelegramConnected] = useState(false);
-  const [discordConnected, setDiscordConnected] = useState(false);
   const [discordGuildMember, setDiscordGuildMember] = useState(false);
   const [referralCode, setReferralCode] = useState('');
+
+  // Read from me.socials directly
+  const socials = me?.socials || { twitter: {}, telegram: {}, discord: {} };
+  const twitterConnected = !!socials?.twitter?.connected;
+  const telegramConnected = !!socials?.telegram?.connected;
+  const discordConnected = !!socials?.discord?.connected;
+  const twitter = stripAt(socials?.twitter?.handle || '');
+  const telegram = stripAt(socials?.telegram?.username || '');
+  const discord = stripAt(socials?.discord?.id || '');
 
   const [perk, setPerk] = useState("");
   const [toast, setToast] = useState("");
@@ -176,7 +178,6 @@ export default function Profile() {
         return;
       }
 
-      setXp(merged.xp ?? 0);
       setTier(merged.tier || merged.subscriptionTier || "Free");
 
       const lvlName = merged.levelName || merged.level || "Shellborn";
@@ -188,13 +189,6 @@ export default function Profile() {
       });
       setPerk(perksMap[lvlName] || "");
 
-      const socials = merged.socials || {};
-      setTwitter(stripAt(socials.twitter?.handle || merged.twitterHandle || merged.twitter));
-      setTelegram(stripAt(socials.telegram?.username || merged.telegramId || merged.telegram));
-      setDiscord(stripAt(socials.discord?.id || merged.discordId || merged.discord));
-      setTwitterConnected(!!socials.twitter?.connected);
-      setTelegramConnected(!!socials.telegram?.connected);
-      setDiscordConnected(!!socials.discord?.connected);
       setDiscordGuildMember(!!merged.discordGuildMember);
       setReferralCode(merged.referral_code || merged.referralCode || "");
 
@@ -417,7 +411,7 @@ export default function Profile() {
                 <strong>Level:</strong> {level.name ?? 'Shellborn'} {level.symbol ?? ''}
               </p>
               <p>
-                <strong>XP:</strong> {xp ?? 0} / {level.nextXP ?? "∞"}
+                <strong>XP:</strong> {me.xp ?? 0} / {me.nextXP ?? "∞"}
               </p>
 
               <div className="xp-bar">

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -114,14 +114,14 @@ export default function Profile() {
   const [discordGuildMember, setDiscordGuildMember] = useState(false);
   const [referralCode, setReferralCode] = useState('');
 
-  // Read from me.socials directly
+  // Prefer new nested socials; gracefully fallback to legacy top-level fields if present
   const socials = me?.socials || { twitter: {}, telegram: {}, discord: {} };
-  const twitterConnected = !!socials?.twitter?.connected;
-  const telegramConnected = !!socials?.telegram?.connected;
-  const discordConnected = !!socials?.discord?.connected;
-  const twitter = stripAt(socials?.twitter?.handle || '');
-  const telegram = stripAt(socials?.telegram?.username || '');
-  const discord = stripAt(socials?.discord?.id || '');
+  const twitterConnected = !!(socials?.twitter?.connected || me?.twitterHandle);
+  const telegramConnected = !!(socials?.telegram?.connected || me?.telegramHandle || me?.telegramId);
+  const discordConnected = !!(socials?.discord?.connected || me?.discordId);
+  const twitter = stripAt(socials?.twitter?.handle || me?.twitterHandle || '');
+  const telegram = stripAt(socials?.telegram?.username || me?.telegramHandle || me?.telegramId || '');
+  const discord = stripAt(socials?.discord?.id || me?.discordId || '');
 
   const [perk, setPerk] = useState("");
   const [toast, setToast] = useState("");

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -137,7 +137,7 @@ export function getLeaderboard({ signal } = {}) {
   if (cached) return Promise.resolve(cached);
   return jsonFetch("/api/leaderboard", { signal }).then((data) => {
     cacheSet("leaderboard", data);
-    return data;
+    return data; // { entries, total }
   });
 }
 


### PR DESCRIPTION
## Summary
- consume `{entries, total}` from leaderboard API and show twitter handles with normalized progress bars
- derive connected socials from `me.socials` and show quest history with accurate XP progress
- document that `getLeaderboard` returns raw JSON `{entries, total}`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68be610663c8832bbaac4706328c4461