### PR TITLE
Fix quest proof flow and profile refresh

### DIFF
--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -56,6 +56,7 @@ export default function Quests() {
       walletRef.current = e?.detail?.wallet || localStorage.getItem('wallet') || '';
       sync();
     };
+    const onProfile = () => sync();
     const onStorage = (e) => {
       if (e.key === 'wallet') {
         onWalletChanged();
@@ -63,11 +64,11 @@ export default function Quests() {
     };
     window.addEventListener('wallet:changed', onWalletChanged);
     window.addEventListener('storage', onStorage);
-    window.addEventListener('profile-updated', sync);
+    window.addEventListener('profile-updated', onProfile);
     return () => {
       window.removeEventListener('wallet:changed', onWalletChanged);
       window.removeEventListener('storage', onStorage);
-      window.removeEventListener('profile-updated', sync);
+      window.removeEventListener('profile-updated', onProfile);
     };
   }, []);
 

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -98,7 +98,7 @@ describe('Quests page claiming', () => {
     await userEvent.type(input, 'https://twitter.com/user/status/1');
 
     submitProof.mockResolvedValueOnce({ status: 'approved' });
-    const submitBtn = screen.getByText('Submit');
+    const submitBtn = screen.getByText('Submit proof');
     await userEvent.click(submitBtn);
 
     await waitFor(() => expect(submitProof).toHaveBeenCalled());

--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -185,7 +185,7 @@ body {
   color: #fff;
   border: 1px solid rgba(255,255,255,0.15);
   border-radius: 10px;
-  padding: 10px 12px;
+  padding: 12px 14px;
   outline: none;
 }
 .inline-proof .input:focus {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -160,10 +160,12 @@ export function getLeaderboard({ signal } = {}) {
  * @param {AbortSignal} [opts.signal]
  * @returns {Promise<MeResponse>}
  */
-export async function getMe({ signal } = {}) {
+export async function getMe({ signal, force } = {}) {
   const key = userKey("me");
-  const cached = cacheGet(key);
-  if (cached) return Promise.resolve(cached);
+  if (!force) {
+    const cached = cacheGet(key);
+    if (cached) return Promise.resolve(cached);
+  }
   return jsonFetch("/api/users/me", { signal }).then((data) => {
     const user = data && typeof data === 'object' && 'user' in data ? data.user : data;
     if (user) cacheSet(key, user);


### PR DESCRIPTION
## Summary
- Allow forcing a fresh `/me` fetch and use it after OAuth or quest updates
- Embed inline proof submission in quest cards and keep "Go" buttons
- Fall back to legacy social fields and update quest history in profile
- Increase inline proof input padding

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68be767c5994832b950b83a7ad95c0f3