### PR TITLE
Fix quest proof flow and profile refresh

### DIFF
--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { submitProof, tierMultiplier } from '../utils/api';
 
-export default function QuestCard({ quest, onClaim, onProof, claiming, me }) {
+export default function QuestCard({ quest, onClaim, claiming, me }) {
   const q = quest;
-  const needsProof = q.requirement && q.requirement !== 'none';
+  const req = String(q.requirement || '').toLowerCase();
+  const needsProof = req && req !== 'none';
   const alreadyClaimed = q.completed || q.alreadyClaimed || q.claimed;
   const claimable = !alreadyClaimed && (!needsProof || q.proofStatus === 'approved');
   const [url, setUrl] = useState('');
@@ -73,7 +74,7 @@ export default function QuestCard({ quest, onClaim, onProof, claiming, me }) {
         </div>
       ) : null}
 
-      {/* Inline proof input when needed and not completed */}
+      {/* Inline proof input (Twitter/Telegram/Discord/link) */}
       {!alreadyClaimed && needsProof && (
         <div className="inline-proof" style={{ display: 'flex', gap: 8, marginTop: 8 }}>
           <input
@@ -81,13 +82,11 @@ export default function QuestCard({ quest, onClaim, onProof, claiming, me }) {
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder={
-              q.requirement === 'join_telegram'
+              req === 'join_telegram' || req === 'telegram'
                 ? 'Paste Telegram message/channel link'
-                : q.requirement === 'join_discord'
+                : req === 'join_discord' || req === 'discord'
                 ? 'Paste Discord invite/message link'
-                : q.requirement === 'tweet' ||
-                  q.requirement === 'retweet' ||
-                  q.requirement === 'quote'
+                : req === 'tweet' || req === 'retweet' || req === 'quote' || req === 'tweet_link'
                 ? 'Paste tweet/retweet/quote link'
                 : 'Paste link here'
             }
@@ -102,6 +101,7 @@ export default function QuestCard({ quest, onClaim, onProof, claiming, me }) {
               setSubmitting(true);
               try {
                 const res = await submitProof(q.id, { url });
+                // Optimistic: reflect backend decision
                 if (res?.status) q.proofStatus = res.status;
                 window.dispatchEvent(new Event('profile-updated'));
               } catch (e) {
@@ -111,27 +111,30 @@ export default function QuestCard({ quest, onClaim, onProof, claiming, me }) {
               }
             }}
           >
-            {submitting ? 'Submitting…' : 'Submit'}
+            {submitting ? 'Submitting…' : 'Submit proof'}
           </button>
         </div>
       )}
 
-      <div className="q-actions">
-        {alreadyClaimed ? (
-          <button className="btn success" disabled>
-            Claimed
-          </button>
-        ) : (
-          <button
-            className="btn ghost"
-            onClick={() => onClaim(q.id)}
-            disabled={claiming || !claimable}
-            title={!claimable && needsProof ? 'Submit proof first' : ''}
-          >
-            {claiming ? 'Claiming...' : 'Claim'}
-          </button>
-        )}
-      </div>
+        <div className="q-actions">
+          {alreadyClaimed ? (
+            <button className="btn success" disabled>
+              Claimed
+            </button>
+          ) : (
+            <button
+              className="btn ghost"
+              onClick={() => onClaim(q.id)}
+              disabled={claiming || !claimable}
+              title={!claimable && needsProof ? 'Submit proof first' : ''}
+            >
+              {claiming ? 'Claiming...' : 'Claim'}
+            </button>
+          )}
+          {q.url ? (
+            <a className="btn primary" href={q.url} target="_blank" rel="noopener noreferrer">Go</a>
+          ) : null}
+        </div>
     </div>
   );
 }

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -98,7 +98,7 @@ describe('Quests page claiming', () => {
     await userEvent.type(input, 'https://twitter.com/user/status/1');
 
     submitProof.mockResolvedValueOnce({ status: 'approved' });
-    const submitBtn = screen.getByText('Submit');
+    const submitBtn = screen.getByText('Submit proof');
     await userEvent.click(submitBtn);
 
     await waitFor(() => expect(submitProof).toHaveBeenCalled());

--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -185,7 +185,7 @@ body {
   color: #fff;
   border: 1px solid rgba(255,255,255,0.15);
   border-radius: 10px;
-  padding: 10px 12px;
+  padding: 12px 14px;
   outline: none;
 }
 .inline-proof .input:focus {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -160,10 +160,12 @@ export function getLeaderboard({ signal } = {}) {
  * @param {AbortSignal} [opts.signal]
  * @returns {Promise<MeResponse>}
  */
-export async function getMe({ signal } = {}) {
+export async function getMe({ signal, force } = {}) {
   const key = userKey("me");
-  const cached = cacheGet(key);
-  if (cached) return Promise.resolve(cached);
+  if (!force) {
+    const cached = cacheGet(key);
+    if (cached) return Promise.resolve(cached);
+  }
   return jsonFetch("/api/users/me", { signal }).then((data) => {
     const user = data && typeof data === 'object' && 'user' in data ? data.user : data;
     if (user) cacheSet(key, user);


### PR DESCRIPTION
## Summary
- Allow forcing a fresh `/me` fetch and use it after OAuth or quest updates
- Embed inline proof submission directly in quest cards, removing the proof modal
- Fall back to legacy social fields and update quest history in profile
- Increase inline proof input padding

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68be767c5994832b950b83a7ad95c0f3