### PR TITLE
7GC polish: quests UI, socials ✅, confetti, throttle binds

### DIFF
--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -447,13 +447,34 @@ export default function Profile() {
               <div className="social-status">
                 <span>X (Twitter):</span>
                 {twitterConnected ? (
-                  twitter ? (
-                    <a className="connected" href={`https://x.com/${twitter}`} target="_blank" rel="noreferrer">✅ @{twitter}</a>
-                  ) : (
-                    <span className="connected">✅ Connected</span>
-                  )
+                  <>
+                    {twitter ? (
+                      <a
+                        className="connected"
+                        href={`https://x.com/${twitter}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        ✅ @{twitter}
+                      </a>
+                    ) : (
+                      <span className="connected">✅ Connected</span>
+                    )}
+                    {/* hide connect button when connected */}
+                  </>
                 ) : (
-                  <div className="social-actions"><button className="mini" onClick={connectTwitter} disabled={connecting.twitter}>Connect</button></div>
+                  <>
+                    <span className="not-connected">❌ Not Connected</span>
+                    <div className="social-actions">
+                      <button
+                        className="mini"
+                        onClick={connectTwitter}
+                        disabled={connecting.twitter}
+                      >
+                        Connect
+                      </button>
+                    </div>
+                  </>
                 )}
               </div>
 
@@ -461,13 +482,34 @@ export default function Profile() {
               <div className="social-status">
                 <span>Telegram:</span>
                 {telegramConnected ? (
-                  telegram ? (
-                    <a className="connected" href={`https://t.me/${telegram}`} target="_blank" rel="noreferrer">✅ @{telegram}</a>
-                  ) : (
-                    <span className="connected">✅ Connected</span>
-                  )
+                  <>
+                    {telegram ? (
+                      <a
+                        className="connected"
+                        href={`https://t.me/${telegram}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        ✅ @{telegram}
+                      </a>
+                    ) : (
+                      <span className="connected">✅ Connected</span>
+                    )}
+                    {/* hide connect button when connected */}
+                  </>
                 ) : (
-                  <div className="social-actions"><button className="mini" onClick={connectTelegram} disabled={connecting.telegram}>Connect</button></div>
+                  <>
+                    <span className="not-connected">❌ Not Connected</span>
+                    <div className="social-actions">
+                      <button
+                        className="mini"
+                        onClick={connectTelegram}
+                        disabled={connecting.telegram}
+                      >
+                        Connect
+                      </button>
+                    </div>
+                  </>
                 )}
               </div>
 
@@ -475,35 +517,60 @@ export default function Profile() {
               <div className="social-status">
                 <span>Discord:</span>
                 {discordConnected ? (
-                  discord ? (
-                    <a className="connected" href={`https://discord.com/users/${discord}`} target="_blank" rel="noreferrer">✅ {discord}</a>
-                  ) : (
-                    <span className="connected">✅ Connected</span>
-                  )
+                  <>
+                    {discord ? (
+                      <a
+                        className="connected"
+                        href={`https://discord.com/users/${discord}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        ✅ {discord}
+                      </a>
+                    ) : (
+                      <span className="connected">✅ Connected</span>
+                    )}
+                    {/* hide connect button when connected */}
+                  </>
                 ) : (
-                  <div className="social-actions"><button className="mini" onClick={connectDiscord} disabled={connecting.discord}>Connect</button></div>
+                  <>
+                    <span className="not-connected">❌ Not Connected</span>
+                    <div className="social-actions">
+                      <button
+                        className="mini"
+                        onClick={connectDiscord}
+                        disabled={connecting.discord}
+                      >
+                        Connect
+                      </button>
+                    </div>
+                  </>
                 )}
               </div>
-          </div>
-        </section>
+            </div>
+          </section>
 
           {/* Quest History */}
           <section className="card glass" style={{ marginTop: 16 }}>
             <h3>📜 Quest History</h3>
             {loading && <p>Loading…</p>}
-            {!loading && (!me?.questHistory || me.questHistory.length === 0) ? (
+            {!loading && (!Array.isArray(me?.questHistory) || me.questHistory.length === 0) ? (
               <p>No quests completed yet.</p>
             ) : (
               <ul>
                 {(me.questHistory || [])
                   .slice()
-                  .sort((a, b) => new Date(b.completed_at || b.created_at || b.timestamp) - new Date(a.completed_at || a.created_at || a.timestamp))
+                  .sort(
+                    (a, b) =>
+                      new Date(b.completed_at || b.created_at || b.timestamp || 0) -
+                      new Date(a.completed_at || a.created_at || a.timestamp || 0)
+                  )
                   .map((q, i) => {
                     const when = q.completed_at || q.created_at || q.timestamp;
                     const ts = when ? new Date(when) : null;
                     return (
-                      <li key={q.questId || i}>
-                        <strong>{q.title || `Quest ${q.questId}`}</strong> — {q.xp ?? 0} XP
+                      <li key={q.id || i}>
+                        {q.title || q.reason || `Quest #${q.quest_id ?? q.id ?? ''}`} — {q.xp ?? q.delta ?? 0} XP
                         {ts ? <span className="timestamp"> • {ts.toLocaleDateString()}</span> : null}
                       </li>
                     );

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -98,7 +98,7 @@ describe('Quests page claiming', () => {
     await userEvent.type(input, 'https://twitter.com/user/status/1');
 
     submitProof.mockResolvedValueOnce({ status: 'approved' });
-    const submitBtn = screen.getByText('Submit proof');
+      const submitBtn = screen.getByText('Submit');
     await userEvent.click(submitBtn);
 
     await waitFor(() => expect(submitProof).toHaveBeenCalled());

--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -209,6 +209,36 @@ body {
 
 /* Improve contrast of chips/buttons over bright art */
 .chip, .btn, .xp-badge {
-  backdrop-filter: saturate(110%) blur(2px);
-  box-shadow: 0 4px 14px rgba(0,0,0,.25);
+    backdrop-filter: saturate(110%) blur(2px);
+    box-shadow: 0 4px 14px rgba(0,0,0,.25);
+}
+
+/* Softer video veil on content pages */
+.page .bg-video + .veil,
+.veil {
+  background: radial-gradient(1200px 400px at 50% 0%, rgba(7,12,24,0.55), transparent 60%),
+              linear-gradient(180deg, rgba(5,8,16,0.75), rgba(5,8,16,0.85));
+}
+
+/* Quest card tidy */
+.quest-card { backdrop-filter: blur(6px); }
+.quest-card .one-link a { font-weight: 700; text-decoration: none; }
+.quest-card .url-line { opacity: .75; font-size: 12px; margin-top: -4px; }
+
+/* Chips & bars */
+.chip.completed { background: rgba(46, 204, 113, .18); border: 1px solid rgba(46,204,113,.5); }
+.chip.pending   { background: rgba(241, 196, 15, .15); border: 1px solid rgba(241,196,15,.45); }
+
+/* Inline proof input */
+.inline-proof .input {
+  background: rgba(255,255,255,0.06);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.14);
+  border-radius: 10px;
+  padding: 10px 12px;
+  outline: none;
+}
+.inline-proof .input:focus {
+  border-color: rgba(135, 206, 250, 0.9);
+  box-shadow: 0 0 0 2px rgba(135, 206, 250, 0.25);
 }

--- a/src/utils/confetti.js
+++ b/src/utils/confetti.js
@@ -1,0 +1,25 @@
+// Lightweight confetti loader that works without bundler changes
+let confettiFn = null;
+
+export async function confettiBurst(opts = {}) {
+  if (!confettiFn) {
+    await new Promise((resolve, reject) => {
+      const s = document.createElement('script');
+      s.src = 'https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js';
+      s.async = true;
+      s.onload = () => {
+        // global confetti is exposed by the script
+        confettiFn = window.confetti || null;
+        resolve();
+      };
+      s.onerror = reject;
+      document.head.appendChild(s);
+    }).catch(() => {});
+  }
+  if (!confettiFn) return;
+
+  const { particleCount = 120, spread = 75, angle = 60, origin = { y: 0.7 } } = opts;
+  confettiFn({ particleCount, spread, angle, origin });
+  confettiFn({ particleCount, spread, angle: 120, origin });
+}
+

--- a/src/utils/init.js
+++ b/src/utils/init.js
@@ -2,16 +2,26 @@ import { ensureWalletBound } from './walletBind';
 import { bindWallet, getMe, getQuests } from './api';
 
 export function setupWalletSync() {
+  let inflight = false;
+  let lastBindAt = 0;
+  const BIND_COOLDOWN_MS = 4000;
   async function sync() {
     const ls = typeof localStorage !== 'undefined' ? localStorage.getItem('wallet') : null;
     const tc = typeof window !== 'undefined' && window.tonconnect?.account?.address;
     const w = ls || tc || null;
     if (w) {
       try {
-        await ensureWalletBound(w);
-        await bindWallet(w);
+        const now = Date.now();
+        if (!inflight && now - lastBindAt > BIND_COOLDOWN_MS) {
+          inflight = true;
+          await ensureWalletBound(w);
+          await bindWallet(w);
+          lastBindAt = Date.now();
+          inflight = false;
+        }
       } catch (e) {
         console.error('[init] bind failed', e);
+        inflight = false;
       }
     }
     try {


### PR DESCRIPTION
## Summary
- streamline Quest cards with one title link and inline proof, firing confetti on approved submissions
- add confetti on quest claim and refresh profile/quest data immediately
- show social connections with legacy fallbacks, tidy quest history, and throttle wallet binds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bea83c9a90832bad634295b4c5350d