### PR TITLE
Refine quest proof flow and reward feedback

### DIFF
--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -76,7 +76,7 @@ export default function QuestCard({ quest, onClaim, claiming, me, setToast }) {
               setSubmitting(true);
               try {
                 const res = await submitProof(q.id, { url });
-                if (res?.status) q.proofStatus = res.status; // optimistic
+                q.proofStatus = res?.status || 'pending'; // optimistic
                 setToast?.('Proof submitted');
                 setTimeout(() => setToast?.(''), 3000);
                 window.dispatchEvent(new Event('profile-updated'));

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -100,7 +100,8 @@ export default function Quests() {
           console.log('claim_clicked', id, res);
         }
         confettiBurst();
-        setToast(res?.xp ? `Quest claimed! +${res.xp} XP` : 'Quest claimed!');
+        const delta = res?.xpDelta ?? res?.xp;
+        setToast(delta != null ? `+${delta} XP` : 'Quest claimed');
         await Promise.all([getMe(), getQuests()]).then(([meData, questsData]) => {
           if (mountedRef.current) {
             setMe(meData);

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -48,7 +48,7 @@ describe('Quests page claiming', () => {
     await waitFor(() => expect(getMe).toHaveBeenCalled());
     await waitFor(() => expect(getQuests).toHaveBeenCalled());
 
-    expect(await screen.findByText('Quest claimed! +50 XP')).toBeInTheDocument();
+    expect(await screen.findByText('+50 XP')).toBeInTheDocument();
   });
 
   test('quest title links to URL when provided', async () => {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -187,8 +187,8 @@ export function claimQuest(id, opts = {}) {
   });
 }
 
-export function submitProof(id, body, opts = {}) {
-  return postJSON(`/api/quests/${id}/proofs`, body, opts).then((res) => {
+export function submitProof(id, { url }, opts = {}) {
+  return postJSON(`/api/quests/${id}/proofs`, { url }, opts).then((res) => {
     clearUserCache();
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new Event('profile-updated'));


### PR DESCRIPTION
## Summary
- Ensure submitting quest proof marks status optimistically and notifies profile update
- Show XP delta on quest claim toast and wire API helper to accept url-only proof
- Adjust quest tests for new reward toast wording

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb65eb060832b9a51386ac73afb81