### PR TITLE
feat: add neon theme and floating effects

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,7 @@
    (Global tokens/background still live in src/index.css)
 -------------------------------------------------------- */
 
+@import "./styles/theme.css";
 /* Typography helper (adding Space Grotesk for futuristic vibe) */
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Space+Grotesk:wght@400;700&display=swap');
 

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,8 @@ import { TonConnectUIProvider } from "@tonconnect/ui-react";
 
 import LeftNav from "./components/LeftNav";
 import ErrorBoundary from "./components/ErrorBoundary";
+import FXCanvas from "./fx/FXCanvas";
+import { getEffectsOff } from "./store/effects";
 import "./App.css";
 import "./styles/polish.css";
 
@@ -55,6 +57,12 @@ function AmbientLayers() {
    App Component
 ----------------------------- */
 const App = () => {
+  const [effectsOff, setEffectsOffState] = React.useState(getEffectsOff());
+  React.useEffect(() => {
+    const on = () => setEffectsOffState(getEffectsOff());
+    window.addEventListener("effects:toggled", on);
+    return () => window.removeEventListener("effects:toggled", on);
+  }, []);
   useEffect(() => {
     // 1) Attach click sound globally
     attachGlobalClickSFX();
@@ -88,6 +96,7 @@ const App = () => {
     <TonConnectUIProvider manifestUrl={manifestUrl}>
       <ErrorBoundary>
         <Router>
+          {!effectsOff && <FXCanvas paused={false} />}
           <AmbientLayers />
           <div className="app-layout">
             <LeftNav />

--- a/src/App.js
+++ b/src/App.js
@@ -85,6 +85,10 @@ const App = () => {
       window.removeEventListener("pointerdown", arm);
       window.removeEventListener("keydown", arm);
     };
+  }, []);
+
+  // Handle landing with ?ref= once on mount
+  useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const ref = params.get('ref');
     if (ref) {

--- a/src/components/LeftNav.jsx
+++ b/src/components/LeftNav.jsx
@@ -1,10 +1,17 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { getEffectsOff, setEffectsOff } from "../store/effects";
 import { Link, NavLink } from "react-router-dom";
 import "./LeftNav.css";
 import logo from "../assets/logo.svg";
 import WalletConnect from "./WalletConnect";
 
 export default function LeftNav() {
+  const [effectsOff, setOff] = useState(getEffectsOff());
+  useEffect(() => {
+    const on = () => setOff(getEffectsOff());
+    window.addEventListener("effects:toggled", on);
+    return () => window.removeEventListener("effects:toggled", on);
+  }, []);
   return (
     <aside className="leftnav" aria-label="Primary">
       <Link to="/" className="brand" aria-label="7GoldenCowries — Home">
@@ -24,6 +31,7 @@ export default function LeftNav() {
 
       <div className="nav-wallet">
         <WalletConnect />
+        <button className="chip" onClick={() => setEffectsOff(!effectsOff)} title={effectsOff ? "Enable FX" : "Disable FX"}>{effectsOff ? "✨ Enable FX" : "🪄 Reduce FX"}</button>
       </div>
     </aside>
   );

--- a/src/components/LeftNav.jsx
+++ b/src/components/LeftNav.jsx
@@ -31,7 +31,16 @@ export default function LeftNav() {
 
       <div className="nav-wallet">
         <WalletConnect />
-        <button className="chip" onClick={() => setEffectsOff(!effectsOff)} title={effectsOff ? "Enable FX" : "Disable FX"}>{effectsOff ? "✨ Enable FX" : "🪄 Reduce FX"}</button>
+        <button
+          className="chip"
+          onClick={() => {
+            setOff(!effectsOff);
+            setEffectsOff(!effectsOff);
+          }}
+          title={effectsOff ? "Enable FX" : "Disable FX"}
+        >
+          {effectsOff ? "✨ Enable FX" : "🪄 Reduce FX"}
+        </button>
       </div>
     </aside>
   );

--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -52,7 +52,7 @@ export default function QuestCard({ quest, onClaim, claiming, me, setToast }) {
         ) : (
           <p className="quest-title">{q.title || q.id}</p>
         )}
-        {q.url ? <div className="muted mono url-line">{q.url}</div> : null}
+        {/* Title is the only link; no duplicate URL preview */}
 
       {/* Inline proof input (only when required and not completed) */}
       {!alreadyClaimed && needsProof && (

--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import useTilt from '../fx/useTilt';
 import { submitProof, tierMultiplier } from '../utils/api';
 
 export default function QuestCard({ quest, onClaim, claiming, me, setToast }) {
@@ -10,9 +11,11 @@ export default function QuestCard({ quest, onClaim, claiming, me, setToast }) {
   const [submitting, setSubmitting] = useState(false);
   const mult = tierMultiplier(me?.tier || me?.subscriptionTier);
   const projected = Math.round((q.xp || 0) * mult);
+  const cardRef = useRef(null);
+  useTilt(cardRef, 8);
 
   return (
-    <div className="glass quest-card">
+    <div ref={cardRef} className="glass quest-card fade-in">
       <div className="q-row">
         {q.type ? (
           <span className={`chip ${q.type}`}>

--- a/src/fx/FXCanvas.js
+++ b/src/fx/FXCanvas.js
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+
+export default function FXCanvas({ paused=false }) {
+  const ref = useRef(null);
+  const raf = useRef(0), dpr = window.devicePixelRatio || 1;
+  useEffect(() => {
+    const c = ref.current; if (!c) return;
+    const ctx = c.getContext('2d');
+    const parts = Array.from({length: 28}).map(() => ({
+      x: Math.random()*innerWidth*dpr,
+      y: Math.random()*innerHeight*dpr,
+      r: (6+Math.random()*14)*dpr,
+      s: (0.15+Math.random()*0.6)*dpr,
+      h: 180 + Math.random()*180, a: 0.20+Math.random()*0.25
+    }));
+    const resize = () => { c.width = innerWidth*dpr; c.height = innerHeight*dpr; };
+    resize(); window.addEventListener('resize', resize);
+
+    const draw = () => {
+      ctx.clearRect(0,0,c.width,c.height);
+      for (const p of parts) {
+        p.y += p.s; if (p.y - p.r > c.height) { p.y = -p.r; p.x = Math.random()*c.width; }
+        ctx.globalAlpha = p.a; ctx.fillStyle = `hsl(${p.h},80%,60%)`;
+        ctx.beginPath(); ctx.arc(p.x, p.y, p.r, 0, Math.PI*2); ctx.fill();
+      }
+      raf.current = requestAnimationFrame(draw);
+    };
+    if (!paused) draw();
+    return () => { cancelAnimationFrame(raf.current); window.removeEventListener('resize', resize); };
+  }, [paused]);
+  return (
+    <canvas
+      ref={ref}
+      style={{position:'fixed', inset:0, zIndex:0, pointerEvents:'none', mixBlendMode:'screen', opacity:.28}}
+      aria-hidden
+    />
+  );
+}

--- a/src/fx/ParallaxLayer.js
+++ b/src/fx/ParallaxLayer.js
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+export default function ParallaxLayer({ depth=20, children, style }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    const el = ref.current; if (!el) return;
+    const on = (e) => {
+      const x = (e.clientX / innerWidth - .5) * depth;
+      const y = (e.clientY / innerHeight - .5) * depth;
+      el.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+    };
+    window.addEventListener('mousemove', on);
+    return () => window.removeEventListener('mousemove', on);
+  }, [depth]);
+  return <div ref={ref} style={{position:'relative', transition:'transform 80ms linear', ...style}}>{children}</div>;
+}

--- a/src/fx/useTilt.js
+++ b/src/fx/useTilt.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+export default function useTilt(ref, strength = 10) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.transformStyle = 'preserve-3d';
+    el.style.willChange = 'transform';
+    const on = (e) => {
+      const r = el.getBoundingClientRect();
+      const px = (e.clientX - r.left) / r.width - 0.5;
+      const py = (e.clientY - r.top) / r.height - 0.5;
+      el.style.transform = `perspective(900px) rotateY(${px*strength}deg) rotateX(${-py*strength}deg) translateZ(0)`;
+    };
+    const off = () => { el.style.transform = 'perspective(900px) rotateY(0) rotateX(0)'; };
+    el.addEventListener('mousemove', on);
+    el.addEventListener('mouseleave', off);
+    return () => { el.removeEventListener('mousemove', on); el.removeEventListener('mouseleave', off); };
+  }, [ref, strength]);
+}

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -6,6 +6,7 @@ import "../App.css";
 import { API_BASE, API_URLS, getMe } from "../utils/api";
 import { ensureWalletBound } from "../utils/walletBind";
 import WalletConnect from "../components/WalletConnect";
+import { burstConfetti } from "../utils/confetti";
 import ConnectButtons from "../components/ConnectButtons";
 
 // Telegram embed constants
@@ -287,6 +288,7 @@ export default function Profile() {
       msg += gm === "true" ? " — server member 🎉" : " — please join our server";
     }
     setToast(msg);
+    burstConfetti();
 
     // Clean URL
     params.delete("connected");
@@ -518,6 +520,7 @@ export default function Profile() {
                       onClick={() => {
                         navigator.clipboard?.writeText(discord);
                         setToast('Discord ID copied ✅');
+                        burstConfetti({count:80,duration:1800});
                         setTimeout(() => setToast(''), 1500);
                       }}
                     >
@@ -603,6 +606,7 @@ export default function Profile() {
                     const link = `${window.location.origin}/?ref=${referralCode}`;
                     navigator.clipboard?.writeText(link);
                     setToast('Referral link copied ✅');
+                    burstConfetti({count:80,duration:1800});
                     setTimeout(() => setToast(''), 1500);
                   }}
                 >

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -5,7 +5,7 @@ import ProfileWidget from '../components/ProfileWidget';
 import QuestCard from '../components/QuestCard';
 import './Quests.css';
 import '../App.css';
-import { confettiBurst } from '../utils/confetti';
+import { burstConfetti } from '../utils/confetti';
 
 export default function Quests() {
   const [quests, setQuests] = useState([]);
@@ -99,7 +99,7 @@ export default function Quests() {
         if (process.env.NODE_ENV !== 'production') {
           console.log('claim_clicked', id, res);
         }
-        confettiBurst();
+        burstConfetti();
         const delta = res?.xpDelta ?? res?.xp;
         setToast(delta != null ? `+${delta} XP` : 'Quest claimed');
         await Promise.all([getMe(), getQuests()]).then(([meData, questsData]) => {

--- a/src/pages/Referral.js
+++ b/src/pages/Referral.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { burstConfetti } from '../utils/confetti';
 import { getMe } from '../utils/api';
 import './Referral.css';
 import '../App.css'; // Import layout classes
@@ -60,6 +61,7 @@ const Referral = () => {
   const handleCopy = () => {
     navigator.clipboard.writeText(referralLink);
     setCopied(true);
+    burstConfetti({count:80,duration:1800});
     setTimeout(() => setCopied(false), 2000);
   };
 

--- a/src/store/effects.js
+++ b/src/store/effects.js
@@ -1,14 +1,17 @@
-export function getEffectsOff() {
+const KEY = 'effects_off';
+
+export const getEffectsOff = () => {
   try {
-    return localStorage.getItem('effects:off') === '1';
+    return localStorage.getItem(KEY) === '1';
   } catch {
     return false;
   }
-}
-export function setEffectsOff(off) {
+};
+
+export const setEffectsOff = (off) => {
   try {
-    if (off) localStorage.setItem('effects:off','1');
-    else localStorage.removeItem('effects:off');
+    if (off) localStorage.setItem(KEY, '1');
+    else localStorage.removeItem(KEY);
   } catch {}
   window.dispatchEvent(new Event('effects:toggled'));
-}
+};

--- a/src/store/effects.js
+++ b/src/store/effects.js
@@ -1,0 +1,14 @@
+export function getEffectsOff() {
+  try {
+    return localStorage.getItem('effects:off') === '1';
+  } catch {
+    return false;
+  }
+}
+export function setEffectsOff(off) {
+  try {
+    if (off) localStorage.setItem('effects:off','1');
+    else localStorage.removeItem('effects:off');
+  } catch {}
+  window.dispatchEvent(new Event('effects:toggled'));
+}

--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -227,3 +227,8 @@ body {
   border-color: rgba(135, 206, 250, 0.9);
   box-shadow: 0 0 0 2px rgba(135, 206, 250, 0.25);
 }
+
+/* Confetti particles */
+.confetti-piece {
+  filter: drop-shadow(0 2px 6px rgba(0,0,0,.2));
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,121 @@
+:root {
+  --bg-0: #07111f;          /* deep sea dusk */
+  --bg-1: #0d1a2b;
+  --card: rgba(18, 28, 45, 0.6);
+  --card-strong: rgba(18, 28, 45, 0.75);
+  --glass-border: rgba(255,255,255,0.16);
+
+  /* Neon ocean spectrum */
+  --cyan: #6fe7ff;
+  --aqua: #49f7dc;
+  --violet: #9d7dff;
+  --pink: #ff7ad9;
+  --sun: #ffd562;
+
+  --text: #e9f2ff;
+  --muted: #a8c1d9;
+
+  /* Gradients */
+  --grad-hero: linear-gradient(135deg, rgba(105,205,255,.24), rgba(255,122,217,.16) 50%, rgba(255,213,98,.16));
+  --grad-chip: linear-gradient(135deg, rgba(105,205,255,.25), rgba(157,125,255,.25));
+  --grad-btn: linear-gradient(180deg, #6fe7ff, #49f7dc);
+  --grad-btn-glow: 0 10px 35px rgba(73,247,220,.35);
+
+  /* Shadows */
+  --shadow-1: 0 10px 30px rgba(3, 8, 20, .35);
+  --shadow-2: 0 18px 60px rgba(3, 8, 20, .55);
+
+  /* Rounding */
+  --r-lg: 18px;
+  --r-xl: 24px;
+
+  /* Motion */
+  --motion-fast: 160ms cubic-bezier(.2,.8,.2,1);
+  --motion-med: 280ms cubic-bezier(.2,.8,.2,1);
+}
+
+/* Lighten overall background; reduce black “veil” feel */
+body {
+  background:
+    radial-gradient(1000px 400px at 10% -10%, rgba(105,205,255,.12), transparent 60%),
+    radial-gradient(1000px 400px at 120% 110%, rgba(255,213,98,.10), transparent 60%),
+    var(--bg-0);
+  color: var(--text);
+}
+
+/* Glass cards (lighter than before) */
+.glass, .card, .quest-card {
+  background: var(--card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-1);
+  backdrop-filter: blur(8px);
+}
+
+/* Stronger panels (hero strips, modals) */
+.glass-strong { background: var(--card-strong); box-shadow: var(--shadow-2); }
+
+/* Buttons */
+.btn, button {
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: #0f2239;
+  color: var(--text);
+  transition: transform var(--motion-fast), box-shadow var(--motion-fast);
+}
+.btn.primary {
+  background: var(--grad-btn);
+  color: #0a1827;
+  box-shadow: var(--grad-btn-glow);
+}
+.btn.primary:hover { transform: translateY(-2px) scale(1.01); }
+
+/* Chips & badges */
+.chip {
+  background: var(--grad-chip);
+  border: 1px solid rgba(255,255,255,.2);
+  padding: 6px 10px;
+  border-radius: 999px;
+  color: var(--text);
+}
+
+/* Links */
+a { color: var(--cyan); }
+a:hover { color: var(--pink); }
+
+/* Inline inputs used on quest proofs */
+.inline-proof .input {
+  background: rgba(255,255,255,0.08);
+  color: var(--text);
+  border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 12px;
+  padding: 10px 12px;
+}
+.inline-proof .input:focus {
+  border-color: var(--aqua);
+  box-shadow: 0 0 0 2px rgba(73,247,220,.28);
+}
+
+/* Progress (XP, leaderboard bars) */
+.progress, .xp-bar, .bar-outer {
+  background: rgba(255,255,255,.08);
+  border: 1px solid rgba(255,255,255,.15);
+  border-radius: 999px;
+}
+.progress-fill, .xp-fill, .bar-inner {
+  background: linear-gradient(90deg, var(--aqua), var(--violet));
+  border-radius: 999px;
+}
+
+/* Softer veil atop videos */
+.veil { background: rgba(4, 10, 20, .45) !important; }
+
+/* Fade-in animation */
+.fade-in { animation: fi .36s var(--motion-med) both; }
+@keyframes fi { from { opacity:0; transform: translateY(8px) } to { opacity:1; transform: translateY(0) } }
+.quest-title { font-size: 1.1rem; font-weight: 700; letter-spacing:.2px; }
+
+/* Podium glows */
+.podium-1 { box-shadow: 0 0 0 2px rgba(255,213,98,.25), 0 10px 40px rgba(255,213,98,.25); }
+.podium-2 { box-shadow: 0 0 0 2px rgba(157,125,255,.25), 0 10px 40px rgba(157,125,255,.25); }
+.podium-3 { box-shadow: 0 0 0 2px rgba(73,247,220,.25), 0 10px 40px rgba(73,247,220,.25); }

--- a/src/utils/confetti.js
+++ b/src/utils/confetti.js
@@ -1,18 +1,22 @@
-export function confettiBurst(opts = {}) {
-  if (typeof window === 'undefined') return;
-  if (process.env.NODE_ENV === 'test') return;
-  try {
-    if (localStorage.getItem('effects:confetti') === 'off') return;
-  } catch (e) {
-    return; // quietly ignore
-  }
-  import('canvas-confetti').then((mod) => {
-    const c = mod.default || mod;
-    c({
-      particleCount: 80,
-      spread: 60,
-      origin: { y: 0.6 },
-      ...opts,
-    });
-  }).catch(() => {});
+export function burstConfetti({count=150,duration=2800}={}) {
+  const el = document.createElement('div'); el.style.position='fixed'; el.style.inset=0; el.style.pointerEvents='none';
+  const cvs = document.createElement('canvas'); el.appendChild(cvs); document.body.appendChild(el);
+  const ctx = cvs.getContext('2d'), dpr = window.devicePixelRatio||1;
+  const resize = () => { cvs.width = innerWidth*dpr; cvs.height = innerHeight*dpr; };
+  resize(); addEventListener('resize', resize);
+  const ps = Array.from({length:count}, (_,i)=>({
+    x: Math.random()*cvs.width, y: -10*dpr, vx: (Math.random()-.5)*3*dpr, vy: (2+Math.random()*6)*dpr,
+    s: (2+Math.random()*4)*dpr, h: ~~(200+Math.random()*150), a: 1, r: Math.random()*Math.PI
+  }));
+  let t = 0, raf;
+  (function loop(){
+    raf = requestAnimationFrame(loop); t += 16;
+    ctx.clearRect(0,0,cvs.width,cvs.height);
+    for (const p of ps) {
+      p.x+=p.vx; p.y+=p.vy; p.vy*=0.995; p.a-=0.006;
+      ctx.save(); ctx.globalAlpha=Math.max(0,p.a); ctx.translate(p.x,p.y); ctx.rotate(p.r+=0.05);
+      ctx.fillStyle=`hsl(${p.h},90%,60%)`; ctx.fillRect(-p.s/2,-p.s/2,p.s,p.s); ctx.restore();
+    }
+    if (t>duration) { cancelAnimationFrame(raf); removeEventListener('resize', resize); el.remove(); }
+  })();
 }

--- a/src/utils/confetti.js
+++ b/src/utils/confetti.js
@@ -1,22 +1,23 @@
-export function burstConfetti({count=150,duration=2800}={}) {
-  const el = document.createElement('div'); el.style.position='fixed'; el.style.inset=0; el.style.pointerEvents='none';
-  const cvs = document.createElement('canvas'); el.appendChild(cvs); document.body.appendChild(el);
-  const ctx = cvs.getContext('2d'), dpr = window.devicePixelRatio||1;
-  const resize = () => { cvs.width = innerWidth*dpr; cvs.height = innerHeight*dpr; };
-  resize(); addEventListener('resize', resize);
-  const ps = Array.from({length:count}, (_,i)=>({
-    x: Math.random()*cvs.width, y: -10*dpr, vx: (Math.random()-.5)*3*dpr, vy: (2+Math.random()*6)*dpr,
-    s: (2+Math.random()*4)*dpr, h: ~~(200+Math.random()*150), a: 1, r: Math.random()*Math.PI
-  }));
-  let t = 0, raf;
-  (function loop(){
-    raf = requestAnimationFrame(loop); t += 16;
-    ctx.clearRect(0,0,cvs.width,cvs.height);
-    for (const p of ps) {
-      p.x+=p.vx; p.y+=p.vy; p.vy*=0.995; p.a-=0.006;
-      ctx.save(); ctx.globalAlpha=Math.max(0,p.a); ctx.translate(p.x,p.y); ctx.rotate(p.r+=0.05);
-      ctx.fillStyle=`hsl(${p.h},90%,60%)`; ctx.fillRect(-p.s/2,-p.s/2,p.s,p.s); ctx.restore();
-    }
-    if (t>duration) { cancelAnimationFrame(raf); removeEventListener('resize', resize); el.remove(); }
-  })();
+export function burstConfetti({ count = 120, duration = 1600 } = {}) {
+  const end = Date.now() + duration;
+  const tick = () => {
+    const p = document.createElement('div');
+    p.className = 'confetti-piece';
+    const size = 6 + Math.random() * 8;
+    p.style.cssText = `
+      position:fixed; left:${Math.random() * 100}vw; top:-10px; width:${size}px; height:${size}px;
+      background:hsl(${Math.random() * 360},100%,60%); border-radius:50%; pointer-events:none; z-index:9999;
+      transform:translate3d(0,0,0); transition:transform ${duration}ms linear, opacity ${duration}ms linear;
+      opacity:1;
+    `;
+    document.body.appendChild(p);
+    requestAnimationFrame(() => {
+      p.style.transform = `translate3d(${(Math.random() * 2 - 1) * 200}px, 110vh, 0) rotate(${Math.random() * 720}deg)`;
+      p.style.opacity = '0';
+    });
+    setTimeout(() => p.remove(), duration + 200);
+    if (Date.now() < end) requestAnimationFrame(tick);
+  };
+  for (let i = 0; i < Math.min(count, 200); i++) tick();
 }
+


### PR DESCRIPTION
## Summary
- introduce new neon ocean theme and gradients
- add floating FX canvas, tilt utility, and custom confetti bursts
- implement global "Reduce FX" toggle and quest/profile polish

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee0ec795c832ba443f4c285b1f8b2