### PR TITLE
fix: honor Reduce FX toggle in confetti bursts

### DIFF
--- a/src/utils/confetti.js
+++ b/src/utils/confetti.js
@@ -1,4 +1,7 @@
+import { getEffectsOff } from '../store/effects';
+
 export function burstConfetti({ count = 120, duration = 1600 } = {}) {
+  if (typeof window === 'undefined' || getEffectsOff()) return;
   const end = Date.now() + duration;
   const tick = () => {
     const p = document.createElement('div');


### PR DESCRIPTION
## Summary
- check Reduce FX setting before running burstConfetti

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bee9f83d58832bab917747730355d4