### PR TITLE
Ensure wallet bind before fetching and polish quest UX

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -125,13 +125,18 @@ export function getJSON(path, opts) {
 }
 
 let bindOncePromise = null;
+let lastBoundWallet = null;
 async function ensureBound() {
   if (typeof window === 'undefined') return;
   const w =
     localStorage.getItem('wallet') || window.tonconnect?.account?.address;
   if (!w) return;
-  if (!bindOncePromise)
-    bindOncePromise = bindWallet(w).catch(() => {});
+  if (w !== lastBoundWallet) {
+    lastBoundWallet = w;
+    bindOncePromise = bindWallet(w).catch(() => {
+      lastBoundWallet = null; // allow retry on failure
+    });
+  }
   return bindOncePromise;
 }
 


### PR DESCRIPTION
## Summary
- Bind TON wallet once before fetching user or quest data to avoid `user:null` races
- Light frontend polish: darker quest cards, single quest link, minimal confetti burst
- Disable social connect buttons once linked and refresh profile/quests on relevant events
- Rebind wallet when address changes so profile and quest fetches wait for the correct binding

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68beedef2798832ba1e3147b36dbf011