### PR TITLE
feat(theme): add YOLO Pop colorful theme + smooth hero video on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,6 +65,13 @@
   </head>
 
   <body>
+    <video id="bg-video" class="bg-video"
+      autoplay muted playsinline loop
+      preload="metadata"
+      poster="/images/hero-poster.jpg">
+      <source src="/video/hero-720p.webm" type="video/webm">
+      <source src="/video/hero-720p.mp4" type="video/mp4">
+    </video>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>

--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -35,7 +35,7 @@ const Leaderboard = () => {
 
   return (
     <div className="leaderboard-wrapper">
-      <h1>🏆 Cowrie Leaderboard</h1>
+      <h1>🏆 <span className="yolo-gradient">Cowrie Leaderboard</span></h1>
       <p className="subtitle">Top explorers across the Seven Isles</p>
 
       {error ? (
@@ -70,10 +70,13 @@ const Leaderboard = () => {
                     <strong>{shorten(user.wallet)}</strong>
                     {user.twitterHandle ? <span> | 🐦 @{user.twitterHandle}</span> : null}
                   </p>
-                  <p>{user.tier} • {user.levelName || 'Shellborn'}</p>
+                  <div className="chips">
+                    <span className="chip">{user.tier}</span>
+                    <span className="chip">{user.levelName || 'Shellborn'}</span>
+                  </div>
                   <div className="progress-container">
-                    <div className="progress-bar">
-                      <div className="progress-fill" style={{ width: `${((user.progress || 0) * 100).toFixed(1)}%` }} />
+                    <div className="bar-outer">
+                      <div className="bar-inner" style={{ width: `${((user.progress || 0) * 100).toFixed(1)}%` }} />
                     </div>
                     <small>{user.xp} XP — {lore[user.levelName || 'Shellborn']}</small>
                   </div>

--- a/src/components/LeftNav.js
+++ b/src/components/LeftNav.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
 import "./LeftNav.css";
 import logo from "../assets/logo.svg";
+import { toggleTheme } from "../utils/theme";
 
 export default function LeftNav() {
   const { pathname } = useLocation();
@@ -71,6 +72,10 @@ export default function LeftNav() {
             <span className="emoji">🌱</span>
             <span>Isles</span>
           </NavLink>
+          <button type="button" className="nav-item" onClick={toggleTheme}>
+            <span className="emoji">🌈</span>
+            <span>Theme</span>
+          </button>
         </nav>
       </aside>
     </>

--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -53,7 +53,7 @@ export default function QuestCard({ quest, onClaim, claiming, me, setToast }) {
         )}
       </p>
       {q.url ? (
-        <div className="muted mono" style={{ wordBreak: 'break-all', color: 'var(--ink-soft)' }}>
+        <div className="muted mono" style={{ color: 'var(--ink-soft)' }}>
           {q.url}
         </div>
       ) : null}

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { TonConnectUIProvider } from "@tonconnect/ui-react";
 import WalletProvider from "./context/WalletContext";
+import './index.css';
 import './styles/polish.css';
 import './styles/theme.css';
+import './styles/yolo.css';
+import { initTheme } from './utils/theme';
+import { initHeroVideo } from './utils/video';
 import { setupWalletSync } from './utils/init';
 import { captureReferralFromQuery } from './utils/referral';
 
@@ -15,11 +19,10 @@ const manifestUrl =
   `${window.location.origin}/tonconnect-manifest.json`;
 
 captureReferralFromQuery();
+initTheme();
+initHeroVideo();
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-
-// Enable colorful “Ocean Light”
-document.body.classList.add('theme-ocean-light');
 
 setupWalletSync();
 

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -293,7 +293,7 @@ export default function Landing() {
 
       {/* ROADMAP */}
       <section className="landing-block roadmap">
-        <h2>Roadmap</h2>
+        <h2><span className="yolo-gradient">Roadmap</span></h2>
         <div className="features-grid">
           <div className="feature-card">
             <div className="chip">Now</div>

--- a/src/pages/Leaderboard.js
+++ b/src/pages/Leaderboard.js
@@ -64,7 +64,7 @@ export default function Leaderboard() {
   return (
     <div className="section">
       <div className="hero glass-strong" style={{ marginBottom: 24 }}>
-        <h1>🏆 Cowrie Leaderboard</h1>
+        <h1>🏆 <span className="yolo-gradient">Cowrie Leaderboard</span></h1>
         <p className="subtitle">Top explorers across the Seven Isles</p>
       </div>
 

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -367,7 +367,7 @@ export default function Profile() {
         </div>
       )}
 
-      <h1 className="section-title">🌊 Explorer Profile</h1>
+      <h1 className="section-title">🌊 <span className="yolo-gradient">Explorer Profile</span></h1>
 
       {loading ? (
         <div className="skeleton" style={{ height: 160, borderRadius: 16 }} />
@@ -456,12 +456,12 @@ export default function Profile() {
                         href={`https://x.com/${twitter}`}
                         target="_blank"
                         rel="noreferrer"
-                        style={{ color: 'var(--success)', fontWeight: 700 }}
+                        style={{ color: 'var(--c-mint)', fontWeight: 800 }}
                       >
                         ✅ @{twitter}
                       </a>
                     ) : (
-                      <span className="connected" style={{ color: 'var(--success)', fontWeight: 700 }}>✅ Connected</span>
+                      <span className="connected" style={{ color: 'var(--c-mint)', fontWeight: 800 }}>✅ Connected</span>
                     )}
                     <div className="social-actions">
                       <button className="mini" disabled title="Already connected">Connect</button>
@@ -494,12 +494,12 @@ export default function Profile() {
                         href={`https://t.me/${telegram}`}
                         target="_blank"
                         rel="noreferrer"
-                        style={{ color: 'var(--success)', fontWeight: 700 }}
+                        style={{ color: 'var(--c-mint)', fontWeight: 800 }}
                       >
                         ✅ @{telegram}
                       </a>
                     ) : (
-                      <span className="connected" style={{ color: 'var(--success)', fontWeight: 700 }}>✅ Connected</span>
+                      <span className="connected" style={{ color: 'var(--c-mint)', fontWeight: 800 }}>✅ Connected</span>
                     )}
                     <div className="social-actions">
                       <button className="mini" disabled title="Already connected">Connect</button>
@@ -526,7 +526,7 @@ export default function Profile() {
                 <span className="muted">Discord:</span>
                 {discordConnected ? (
                   <>
-                    <span className="connected" style={{ color: 'var(--success)', fontWeight: 700 }}>✅ {discord || 'Connected'}</span>
+                    <span style={{ color: 'var(--c-mint)', fontWeight: 800 }}>✅ {discord}</span>
                     <div className="social-actions">
                       {discord ? (
                         <button

--- a/src/pages/Quests.js
+++ b/src/pages/Quests.js
@@ -137,9 +137,6 @@ export default function Quests() {
 
   return (
     <div className="page">
-      <video autoPlay loop muted playsInline className="bg-video">
-        <source src="/videos/sea-goddess.mp4" type="video/mp4" />
-      </video>
       <div className="veil" />
 
       <div className="q-container">
@@ -150,7 +147,7 @@ export default function Quests() {
         <div className="glass-strong q-header">
           <div className="q-title">
             <span className="emoji">📜</span>
-            <h1>Quests</h1>
+            <h1><span className="yolo-gradient">Quests</span></h1>
           </div>
           <p className="subtitle">Complete tasks. Earn XP. Level up.</p>
           <div className="tabs">

--- a/src/pages/TokenSale.js
+++ b/src/pages/TokenSale.js
@@ -12,7 +12,7 @@ export default function TokenSale() {
         {/* HERO */}
         <section className="section ts-hero card gradient-border pad-24 fade-in">
           <div className="ts-hero-head">
-            <h1 className="soft-title text-glow">$GCT — Golden Cowrie Token</h1>
+            <h1 className="soft-title text-glow">$GCT — <span className="yolo-gradient">Golden Cowrie Token</span></h1>
             <div className="ts-badge">First Wave • Oct 4, 2025 (UTC)</div>
           </div>
 
@@ -85,7 +85,7 @@ export default function TokenSale() {
 
         {/* ROADMAP */}
         <section className="section card gradient-border pad-24 hover ts-roadmap">
-          <h3 className="soft-title">Roadmap • Waves of Release</h3>
+          <h3 className="soft-title"><span className="yolo-gradient">Roadmap • Waves of Release</span></h3>
           <ol className="ts-steps">
             <li><b>First Wave</b> — Presale opens, XP blessing airdrops, lore reveal.</li>
             <li><b>Second Wave</b> — Premium Isles unlocks, governance proposals begin.</li>

--- a/src/styles/yolo.css
+++ b/src/styles/yolo.css
@@ -1,0 +1,116 @@
+/* YOLO Pop — bright, friendly, readable */
+:root {
+  --radius: 14px;
+  --shadow-xl: 0 22px 55px -18px rgba(7,16,28,.25);
+  --blur: 10px;
+
+  /* Base (kept, for Deep/Ocean) */
+  --bg: #0f2236;
+  --panel: rgba(255,255,255,.82);
+  --ink: #0b1f33;
+  --ink-soft: #476281;
+  --chip-ink: #0e2435;
+
+  /* Accent ramp (YOLO-inspired) */
+  --c-pink:  #FF7AB6;
+  --c-peach: #FFB37A;
+  --c-yellow:#FFE875;
+  --c-mint:  #7BFFC9;
+  --c-sky:   #6BD1FF;
+  --c-violet:#9C83FF;
+
+  /* UI tokens */
+  --link: #3c82ff;
+  --link-hover: #2f6de1;
+
+  --panel-strong: rgba(255,255,255,.92);
+  --card-border: rgba(255,255,255,.6);
+
+  --chip-bg: rgba(255,255,255,.96);
+  --bar-bg: rgba(14,34,54,.08);
+  --bar-fill: linear-gradient(90deg, var(--c-pink), var(--c-peach), var(--c-yellow), var(--c-mint), var(--c-sky), var(--c-violet));
+}
+
+/* THEME: yolo-pop — overrides */
+body.theme-yolo-pop {
+  --bg: #0f1f2f;              /* darker canvas to let pastel pop */
+  --panel: rgba(255,255,255,.90);
+  --panel-strong: rgba(255,255,255,.98);
+  --blur: 12px;
+}
+
+/* Utility styles that consume tokens */
+.glass, .card.glass, .quest-card, .profile-card, .leader-card {
+  background: var(--panel);
+  backdrop-filter: blur(var(--blur));
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-xl);
+  color: var(--ink);
+}
+
+.veil { background: rgba(7,16,28,.22); } /* lighter veil to avoid darkening */
+
+.chip {
+  background: var(--chip-bg);
+  color: var(--chip-ink);
+  border-radius: 999px;
+  border: 1px solid rgba(16,31,46,.12);
+  padding: 6px 12px;
+  font-weight: 700;
+  letter-spacing: .2px;
+}
+
+/* Rainbow headline & dividers */
+.yolo-gradient {
+  background: linear-gradient(90deg, var(--c-pink), var(--c-peach), var(--c-yellow), var(--c-mint), var(--c-sky), var(--c-violet));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Progress bars pick up rainbow */
+.bar-outer, .xp-bar { background: var(--bar-bg); border-radius: 999px; }
+.bar-inner, .xp-fill { background: var(--bar-fill); height: 8px; }
+
+/* Buttons */
+.btn.primary {
+  background-image: linear-gradient(90deg, var(--c-sky), var(--c-violet));
+  color: #fff; border: 0;
+}
+.btn.primary:hover { filter: saturate(1.08) brightness(1.04); transform: translateY(-1px); }
+
+/* Links */
+a, .quest-title a { color: var(--link); }
+a:hover, .quest-title a:hover { color: var(--link-hover); text-decoration: underline; }
+
+/* Mobile spacing polish */
+.section { padding-bottom: 20px; }
+.row.glass, .card.glass { margin-bottom: 12px; }
+
+/* Prefers reduced motion: disable heavy effects */
+@media (prefers-reduced-motion: reduce) {
+  .glass, .card.glass, .quest-card, .profile-card, .leader-card { backdrop-filter: none; }
+}
+
+/* Inline proof input */
+.inline-proof .input {
+  background: rgba(255,255,255,.98);
+  color: var(--ink);
+  border: 1px solid rgba(16,31,46,.15);
+}
+.inline-proof .input::placeholder { color: #6984a0; }
+
+/* Reduce expensive filters on mobile */
+.video-mobile .veil { background: rgba(7,16,28,.18); }
+.video-mobile .glass, .video-mobile .card.glass { backdrop-filter: blur(6px); }
+
+#bg-video, .bg-video {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  object-fit: cover;
+  z-index: 0;
+}
+

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,9 @@
+export function initTheme() {
+  const savedTheme = localStorage.getItem('theme');
+  document.body.classList.toggle('theme-yolo-pop', savedTheme ? savedTheme === 'yolo' : true);
+}
+
+export function toggleTheme() {
+  const isYolo = document.body.classList.toggle('theme-yolo-pop');
+  localStorage.setItem('theme', isYolo ? 'yolo' : 'deep');
+}

--- a/src/utils/video.js
+++ b/src/utils/video.js
@@ -1,0 +1,17 @@
+export function initHeroVideo() {
+  const v = document.getElementById('bg-video');
+  if (!v) return;
+
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) v.play().catch(() => {});
+      else v.pause();
+    });
+  }, { threshold: 0.15 });
+  io.observe(v);
+
+  v.addEventListener('loadedmetadata', () => { v.muted = true; v.play().catch(() => {}); });
+
+  const isMobile = /Mobi|Android/i.test(navigator.userAgent);
+  if (isMobile) document.body.classList.add('video-mobile');
+}


### PR DESCRIPTION
## Summary
- add YOLO Pop palette with shared tokens and rainbow accents
- introduce theme toggle and persist choice
- preload hero video metadata and pause off-screen for mobile performance

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68befdb7a85c832ba87e2383d1090002