### PR TITLE
feat(theme): YOLO Pop restyle

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
    7GoldenCowries — Global UI
    Enchanted Ocean Theme (v2)
    =========================== */
+@import "./styles/tokens.css";
 
 /* ===== Theme Tokens ===== */
 :root{
@@ -158,6 +159,92 @@ a:hover { text-decoration: underline; }
 .gap-8 { gap: 8px; }
 .gap-12 { gap: 12px; }
 .gap-16 { gap: 16px; }
+.gap-24 { gap: 24px; }
+
+/* === YOLO Pop overrides === */
+html, body {
+  background: radial-gradient(1200px 800px at 70% 40%, #10224a 0%, #0b1330 50%, #0a0f26 100%);
+  color: var(--txt);
+}
+
+.container, .section {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.hero {
+  background: var(--glass-strong);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
+}
+
+.card, .glass {
+  background: var(--glass);
+  border: 1px solid rgba(255,255,255,.09);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
+  backdrop-filter: blur(6px);
+}
+
+.glass-strong { background: var(--glass-strong); }
+
+h1, h2, h3 { letter-spacing: .3px; }
+h1 {
+  font-size: clamp(28px, 3.5vw, 40px);
+  background: var(--grad-1);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.subtitle { color: var(--txt-muted); }
+
+/* Buttons, chips */
+.btn, .chip {
+  border-radius: 999px;
+  padding: 8px 14px;
+  border: 1px solid rgba(255,255,255,.16);
+  background: radial-gradient(120px 80px at 20% 20%, rgba(255,255,255,.16), rgba(255,255,255,.06));
+  color: var(--txt);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.12);
+}
+.btn-primary {
+  background: var(--grad-2);
+  color: #102;
+  border: 0;
+  box-shadow: var(--shadow-1);
+}
+.btn:hover { transform: translateY(-1px); }
+
+/* Progress bars */
+.bar-outer {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(255,255,255,.15);
+  overflow: hidden;
+}
+.bar-inner {
+  height: 100%;
+  background: var(--grad-1);
+}
+
+/* Circular % (Isles) */
+.radial {
+  --p: 0.13; /* 0–1 */
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: conic-gradient(var(--c-blue) calc(var(--p)*1turn), rgba(255,255,255,.15) 0);
+  mask: radial-gradient(closest-side, #0000 74%, #000 75%);
+}
+
+/* Menu sheet veil lighter */
+.drawer-veil { background: rgba(12,18,36,.35); }
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .parallax, .sparkles { display:none !important; }
+}
 .pad-16 { padding: 16px; }
 .pad-24 { padding: 24px; }
 .round { border-radius: var(--r-lg); }

--- a/src/pages/Leaderboard.js
+++ b/src/pages/Leaderboard.js
@@ -76,7 +76,15 @@ export default function Leaderboard() {
             <div className="big-wallet">
               {abbreviateWallet(u.wallet)}
               {u.twitterHandle ? (
-                <span className="muted" style={{ marginLeft: 6 }}>@{u.twitterHandle}</span>
+                <a
+                  className="muted"
+                  style={{ marginLeft: 6 }}
+                  href={`https://x.com/${u.twitterHandle}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  @{u.twitterHandle}
+                </a>
               ) : null}
             </div>
             <div className="chips">
@@ -103,7 +111,15 @@ export default function Leaderboard() {
                 <div className="wallet mono">
                   {abbreviateWallet(u.wallet)}
                   {u.twitterHandle ? (
-                    <span className="muted" style={{ marginLeft: 4 }}>@{u.twitterHandle}</span>
+                    <a
+                      className="muted"
+                      style={{ marginLeft: 4 }}
+                      href={`https://x.com/${u.twitterHandle}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      @{u.twitterHandle}
+                    </a>
                   ) : null}
                 </div>
                 <div className="badges">

--- a/src/pages/TokenSale.js
+++ b/src/pages/TokenSale.js
@@ -1,10 +1,31 @@
 // src/pages/TokenSale.js
-import React from "react";
+import React, { useEffect, useState } from "react";
 import "./TokenSale.css";
-import { useCountdown, SALE_START_ISO, openCalendarReminder, inviteFriend } from "../utils/launch";
+import { SALE_START_ISO, openCalendarReminder, inviteFriend } from "../utils/launch";
+
+const TARGET = Date.UTC(2025, 9, 4, 0, 0, 0); // Oct 4, 2025 00:00:00 UTC
+
+function getTimeLeft() {
+  const now = Date.now();
+  let diff = Math.max(0, Math.floor((TARGET - now) / 1000));
+  const days = Math.floor(diff / 86400);
+  diff -= days * 86400;
+  const hours = Math.floor(diff / 3600);
+  diff -= hours * 3600;
+  const mins = Math.floor(diff / 60);
+  const secs = diff % 60;
+  return { days, hours, mins, secs, finished: TARGET - now <= 0 };
+}
 
 export default function TokenSale() {
-  const { days, hours, minutes, seconds, finished } = useCountdown(SALE_START_ISO);
+  const [time, setTime] = useState(getTimeLeft());
+
+  useEffect(() => {
+    const id = setInterval(() => setTime(getTimeLeft()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const { days, hours, mins, secs, finished } = time;
 
   return (
     <div className="page">
@@ -29,10 +50,10 @@ export default function TokenSale() {
             </div>
             {!finished ? (
               <div className="ts-countdown-grid">
-                <div className="ts-time"><span>{days}</span><label>days</label></div>
-                <div className="ts-time"><span>{hours}</span><label>hours</label></div>
-                <div className="ts-time"><span>{minutes}</span><label>mins</label></div>
-                <div className="ts-time"><span>{seconds}</span><label>secs</label></div>
+                <div className="ts-time"><span>{String(days).padStart(2, '0')}</span><label>days</label></div>
+                <div className="ts-time"><span>{String(hours).padStart(2, '0')}</span><label>hours</label></div>
+                <div className="ts-time"><span>{String(mins).padStart(2, '0')}</span><label>mins</label></div>
+                <div className="ts-time"><span>{String(secs).padStart(2, '0')}</span><label>secs</label></div>
               </div>
             ) : (
               <div className="ts-live-note">Follow updates in-app and socials—waves are moving.</div>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,30 @@
+:root {
+  /* Base surface */
+  --bg: #0e1530;               /* lighter than before */
+  --bg-2: #111a3c;
+  --glass: rgba(255,255,255,.08);
+  --glass-strong: rgba(255,255,255,.12);
+  --veil: rgba(10,25,40,.14);
+
+  /* Text */
+  --txt: #eaf2ff;
+  --txt-muted: #b7c2e1;
+  --txt-invert: #0b1024;
+
+  /* YOLO pop gradient accents */
+  --c-pink:   #ff6bd5;
+  --c-purple: #8a7dff;
+  --c-blue:   #37b6ff;
+  --c-cyan:   #43ffd3;
+  --c-lime:   #b5ff52;
+  --c-sun:    #ffd15a;
+
+  /* Shared gradient */
+  --grad-1: linear-gradient(135deg,var(--c-pink),var(--c-purple),var(--c-blue));
+  --grad-2: linear-gradient(135deg,var(--c-cyan),var(--c-lime),var(--c-sun));
+
+  /* Cards & shadows */
+  --radius: 16px;
+  --shadow-1: 0 6px 30px rgba(0,0,0,.25);
+  --shadow-2: 0 12px 50px rgba(0,0,0,.35);
+}


### PR DESCRIPTION
## Summary
- add bright YOLO Pop design tokens and import globally
- restyle layout and components with lighter glass and gradients
- fix token sale countdown using UTC target date
- link leaderboard Twitter handles to X profiles

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bf07469e10832b8326356e2c5590bd