### PR TITLE
Apply enchanted theme with fixed sidebar and centered pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Isles from './pages/Isles';
 import Referral from './pages/Referral';
 import Subscription from './pages/Subscription';
 import TokenSale from './pages/TokenSale';
+import RefRedirect from './pages/RefRedirect';
 
 export default function App() {
   return (
@@ -24,6 +25,7 @@ export default function App() {
           <Route path="/profile" element={<Profile />} />
           <Route path="/isles" element={<Isles />} />
         </Route>
+        <Route path="/ref/:code" element={<RefRedirect />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -357,4 +357,3 @@ body::after{
 /* Ensure media never overflows */
 img, video, canvas { max-width: 100%; height: auto; display: block; }
 
-@import "./styles/enchanted.css";

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import './index.css';
 import './styles/polish.css';
 import './styles/theme.css';
 import './styles/yolo.css';
+import './styles/enchanted.css';
 import { initTheme } from './utils/theme';
 import { initHeroVideo } from './utils/video';
 import { setupWalletSync } from './utils/init';


### PR DESCRIPTION
## Summary
- add enchanted.css theme and import globally
- implement fixed sidebar with mobile drawer and background layers
- wrap pages in reusable `<Page>` to center content
- restore referral redirect route
- import enchanted sidebar stylesheet

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bf2c6191f4832b9b8f68c7aea47815