### PR TITLE
Fix sidebar layout overflow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -581,9 +581,14 @@ input:focus, select:focus, textarea:focus {
 
 /* Ensure main content isn’t hidden behind fixed sidebar on desktop */
 @media (min-width: 1025px) {
+  .app-layout {
+    box-sizing: border-box;
+    padding-left: var(--sidebar-w);
+  }
+
   .app-layout .main-view {
-    margin-left: var(--sidebar-w);
-    width: calc(100% - var(--sidebar-w));
+    margin-left: 0;
+    width: 100%;
   }
 }
 

--- a/src/components/LeftNav.css
+++ b/src/components/LeftNav.css
@@ -118,11 +118,6 @@
   justify-content: center;
 }
 
-/* Push main content so it doesn't sit under the fixed sidebar (desktop only) */
-@media (min-width: 1025px){
-  .app-layout .main-view{ margin-left: var(--sidebar-w); }
-}
-
 /* On smaller screens, main content is full-width. Sidebar is a drawer. */
 @media (max-width: 1024px){
   .app-layout .main-view{ margin-left: 0; }

--- a/src/styles/enchanted.css
+++ b/src/styles/enchanted.css
@@ -19,11 +19,6 @@
   margin: 0 auto;
 }
 
-/* Desktop offset so content isn't under the fixed sidebar */
-@media (min-width: 1025px) {
-  .app-layout .main-view { margin-left: var(--sidebar-w); }
-}
-
 /* Sections & Cards */
 .section { margin-bottom: 32px; }
 


### PR DESCRIPTION
## Summary
- Prevent main content overflow by subtracting sidebar width from main view on desktop

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c3f8aea310832baec1f38240af2ead