### PR TITLE
fix: restore responsive layout

### DIFF
--- a/src/components/layout/AppLayout.jsx
+++ b/src/components/layout/AppLayout.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import Sidebar from "./Sidebar";
-import "./AppLayout.css"; // layout & responsive rules
+import "./AppLayout.css"; // responsive flex layout rules
 
 export default function AppLayout({ children }) {
   return (
-    <div className="app-layout">
+    <div className="app-layout">{/* flex container so main area can grow */}
       <Sidebar />
       {/* Ambient layers */}
       <div id="magic-orbs">

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -19,7 +19,7 @@ export default function Sidebar() {
   const { pathname } = useLocation();
   const [open, setOpen] = useState(false);
 
-  // Close drawer on route change
+  // Close drawer on route change (ensures drawer hides after navigation on mobile)
   useEffect(() => {
     setOpen(false);
   }, [pathname]);

--- a/src/index.css
+++ b/src/index.css
@@ -72,14 +72,7 @@ a:hover { text-decoration: underline; }
 }
 ::-webkit-scrollbar-track { background: transparent; }
 
-/* ===== Layout ===== */
-.app-layout{
-  display:grid; grid-template-columns: 280px 1fr; min-height:100vh;
-}
-.main-view{
-  padding: 24px 24px 60px;
-  max-width: 1280px; width:100%; margin:0 auto;
-}
+/* ===== Layout (moved to component styles; keep utility containers) ===== */
 .container { max-width: 1160px; margin: 0 auto; padding: var(--pad); }
 .section { padding: 18px; }
 
@@ -268,8 +261,7 @@ h1 {
 
 /* ===== Responsive ===== */
 @media (max-width: 960px){
-  .app-layout{ grid-template-columns: 1fr; }
-  .main-view{ padding: 18px 16px 70px; }
+  /* core layout handled in component styles; keep utility spacing tweaks */
   .container { padding: 16px; }
   .section { padding: 12px; }
   .btn { padding: 10px 16px; }


### PR DESCRIPTION
## Summary
- remove obsolete grid layout so main view can flex to full width
- document flex-based AppLayout and ensure sidebar drawer closes after navigation
- clean responsive utilities in index.css

## Testing
- `npm start`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c4b5dcd3e4832b875930609b2d9643