### PR TITLE
Polish quests, profile, leaderboard, and layout

### DIFF
--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -2,7 +2,15 @@ import React, { useState, useRef } from 'react';
 import useTilt from '../fx/useTilt';
 import { submitProof, tierMultiplier } from '../utils/api';
 
-export default function QuestCard({ quest, onClaim, claiming, me, setToast, canClaim = true }) {
+export default function QuestCard({
+  quest,
+  onClaim,
+  claiming,
+  me,
+  setToast,
+  canClaim = true,
+  blockedReason,
+}) {
   const q = quest;
   const needsProof = q.requirement && q.requirement !== 'none';
   const alreadyClaimed = q.completed || q.alreadyClaimed || q.claimed;
@@ -13,6 +21,10 @@ export default function QuestCard({ quest, onClaim, claiming, me, setToast, canC
   const projected = Math.round((q.xp || 0) * mult);
   const cardRef = useRef(null);
   useTilt(cardRef, 8);
+  const isBlocked = Boolean(blockedReason);
+  const blockedTooltip = blockedReason === 'proof-required'
+    ? 'Submit proof before claiming'
+    : blockedReason || '';
 
   return (
     <div ref={cardRef} className="glass quest-card fade-in">
@@ -104,21 +116,28 @@ export default function QuestCard({ quest, onClaim, claiming, me, setToast, canC
         {alreadyClaimed ? (
           <button className="btn success" disabled>Claimed</button>
         ) : (
-          <button
-            className="btn ghost"
-            onClick={() => onClaim(q.id)}
-            disabled={claiming || !claimable || !canClaim}
-            title={
-              !canClaim
-                ? 'Connect wallet to claim'
-                : !claimable && needsProof
-                ? 'Submit proof first'
-                : ''
-            }
-            aria-disabled={claiming || !claimable || !canClaim}
-          >
-            {claiming ? 'Claiming...' : 'Claim'}
-          </button>
+          <>
+            {isBlocked && blockedReason === 'proof-required' ? (
+              <p className="muted proof-note">Proof required — submit your link above.</p>
+            ) : null}
+            <button
+              className="btn ghost"
+              onClick={() => onClaim?.(q)}
+              disabled={claiming || !claimable || !canClaim || isBlocked}
+              title={
+                !canClaim
+                  ? 'Connect wallet to claim'
+                  : isBlocked
+                  ? blockedTooltip
+                  : !claimable && needsProof
+                  ? 'Submit proof first'
+                  : ''
+              }
+              aria-disabled={claiming || !claimable || !canClaim || isBlocked}
+            >
+              {claiming ? 'Claiming...' : 'Claim'}
+            </button>
+          </>
         )}
       </div>
     </div>

--- a/src/components/layout/Sidebar.css
+++ b/src/components/layout/Sidebar.css
@@ -11,8 +11,8 @@
   z-index: 100;
   width: 42px; height: 36px;
   border-radius: 10px;
-  border: 1px solid rgba(255,255,255,.16);
-  background: rgba(255,255,255,.06);
+  border: 1px solid rgba(102,224,255,.35);
+  background: linear-gradient(135deg, rgba(102,224,255,.18), rgba(6,19,37,.7));
   backdrop-filter: blur(8px);
   display: grid; place-items: center;
   gap: 3px; padding: 6px 0;
@@ -20,7 +20,7 @@
 .nav-toggle .bar{
   display: block;
   width: 22px; height: 2px;
-  background: #cfe9ff; border-radius: 2px;
+  background: #e0f7ff; border-radius: 2px;
 }
 @media (min-width: 1025px){
   .nav-toggle{ display: none; }
@@ -50,6 +50,25 @@
   transition: transform .25s ease;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+}
+
+.leftnav::before,
+.leftnav::after{
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.leftnav::before{
+  background: radial-gradient(160% 60% at 20% 0%, rgba(102,224,255,0.22), transparent 60%),
+              radial-gradient(120% 70% at 80% 100%, rgba(122,125,255,0.18), transparent 65%);
+  opacity: .8;
+}
+
+.leftnav::after{
+  background: linear-gradient(0deg, rgba(6,19,37,0.25), transparent 35%);
 }
 
 /* Drawer behavior on small screens */

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -20,7 +20,7 @@ export default function Home() {
       <div className="aurora" aria-hidden="true" />
       <div className="bg-particles" aria-hidden="true">
         {particles.map((_, i) => (
-          <span key={i} style={{ ["--i"]: i }} />
+          <span key={i} style={{ '--i': i }} />
         ))}
       </div>
 

--- a/src/pages/Isles.jsx
+++ b/src/pages/Isles.jsx
@@ -209,16 +209,18 @@ function useProfile(address) {
         // 1) Prefer session-aware /api/users/me
         const me = await getMe().catch(() => null);
         if (me?.authed) {
-          const norm = normalizeUser(me, profile);
-          if (!cancelled) setProfile(norm);
+          if (!cancelled) {
+            setProfile((prev) => normalizeUser(me, prev));
+          }
         } else if (address) {
           // 2) Fallback to legacy /api/profile?wallet=
           const url = `${API}/api/profile?wallet=${encodeURIComponent(address)}`;
           const res = await fetch(url, { credentials: "include" });
           if (res.ok) {
             const data = await res.json();
-            const norm = normalizeUser(data, profile);
-            if (!cancelled) setProfile(norm);
+            if (!cancelled) {
+              setProfile((prev) => normalizeUser(data, prev));
+            }
           }
         }
       } catch (e) {

--- a/src/pages/Leaderboard.css
+++ b/src/pages/Leaderboard.css
@@ -15,6 +15,14 @@
   max-width: 1100px; margin: 0 auto; padding: 28px;
 }
 
+.lb-header {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  text-align: center;
+  margin-bottom: 24px;
+}
+
 .leaderboard-wrapper h1 {
   font-size: 2.2rem;
   margin: 0 0 6px;
@@ -24,6 +32,20 @@
 }
 .leaderboard-wrapper .subtitle {
   text-align: center;
+}
+
+.lb-fallback {
+  margin: clamp(48px, 12vw, 96px) auto;
+  padding: clamp(24px, 6vw, 48px);
+  border-radius: 20px;
+  max-width: 520px;
+  text-align: center;
+  display: grid;
+  gap: 12px;
+}
+
+.lb-fallback.error {
+  border: 1px solid rgba(255, 122, 122, 0.35);
 }
 
 /* -------------------
@@ -47,6 +69,10 @@
   border-color: rgba(255,255,255,0.18);
   box-shadow: 0 16px 38px rgba(0,0,0,0.4), 0 0 28px rgba(122,125,255,0.18);
 }
+.podium-step.me {
+  border-color: rgba(255,212,102,0.4);
+  box-shadow: 0 16px 40px rgba(255,212,102,0.25), 0 0 32px rgba(255,212,102,0.18);
+}
 .podium-step.tall { transform: translateY(-6px); }
 .podium-step.ghost { height: 220px; opacity: .18; }
 
@@ -64,6 +90,40 @@
 .pill {
   padding: 5px 10px; border-radius: 999px; font-weight: 700; font-size: 12px;
   background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.1);
+}
+
+.tier-badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 12px;
+  letter-spacing: 0.3px;
+  background: linear-gradient(135deg, rgba(102,224,255,0.28), rgba(122,125,255,0.24));
+  border: 1px solid rgba(102,224,255,0.35);
+  color: #e6f7ff;
+  text-transform: capitalize;
+}
+
+.tier-badge.free {
+  background: linear-gradient(135deg, rgba(255,255,255,0.12), rgba(255,255,255,0.06));
+  border-color: rgba(255,255,255,0.2);
+  color: #f0f6ff;
+}
+
+.tier-badge.tier-1 {
+  background: linear-gradient(135deg, rgba(102,224,255,0.42), rgba(78,196,255,0.35));
+  border-color: rgba(102,224,255,0.5);
+}
+
+.tier-badge.tier-2 {
+  background: linear-gradient(135deg, rgba(168,118,255,0.45), rgba(132,92,255,0.38));
+  border-color: rgba(168,118,255,0.5);
+}
+
+.tier-badge.tier-3 {
+  background: linear-gradient(135deg, rgba(255,212,102,0.5), rgba(255,160,80,0.45));
+  border-color: rgba(255,212,102,0.55);
+  color: #2a1e00;
 }
 
 /* Link style used for Twitter handles */
@@ -117,6 +177,10 @@
   border-color: rgba(255,255,255,0.16);
   box-shadow: 0 12px 24px rgba(0,0,0,0.25);
 }
+.leader-card.me {
+  border-color: rgba(255,212,102,0.4);
+  box-shadow: 0 12px 30px rgba(255,212,102,0.22);
+}
 .rank-badge {
   width: 56px; height: 56px; border-radius: 12px; display: grid; place-items: center;
   font-weight: 900; color: #06131f;
@@ -129,7 +193,13 @@
   border: 1px solid rgba(255,255,255,0.10);
   filter: drop-shadow(0 0 12px rgba(102,224,255,0.25));
 }
-.user-meta .user-line { line-height: 1.2rem; }
+.user-meta .user-line {
+  line-height: 1.2rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
 .user-meta .user-line.muted { margin-top: 4px; }
 
 /* -------------------

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -2,6 +2,52 @@ import React, { useEffect, useRef, useState } from 'react';
 import { getLeaderboard } from '../utils/api';
 import { abbreviateWallet } from '../lib/format';
 import Page from '../components/Page';
+import './Leaderboard.css';
+
+const REFRESH_MS = 60000;
+
+const clampProgress = (value) => Math.max(0, Math.min(1, Number(value) || 0));
+
+const prettifyTier = (tier) => {
+  if (!tier) return 'Free';
+  const label = String(tier).trim();
+  if (/^tier\s*\d/i.test(label)) {
+    const match = label.match(/\d/);
+    return match ? `Tier ${match[0]}` : label;
+  }
+  if (label.toLowerCase() === 'free') return 'Free';
+  return label;
+};
+
+const tierSlug = (tier) =>
+  prettifyTier(tier)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+
+const levelBadgeSrc = (levelName) => {
+  const base = String(levelName || 'Shellborn')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+  return `/images/badges/level-${base}.png`;
+};
+
+const TierBadge = ({ tier }) => {
+  const label = prettifyTier(tier);
+  const slug = tierSlug(tier);
+  return <span className={`tier-badge ${slug}`}>{label}</span>;
+};
+
+const ProgressMeter = ({ progress }) => {
+  const pct = Math.round(clampProgress(progress) * 1000) / 10;
+  return (
+    <div className="progress-wrap compact" aria-label={`Progress ${pct}%`}>
+      <div className="progress-bar">
+        <div className="progress-fill" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="muted">{pct}% to next level</span>
+    </div>
+  );
+};
 
 export default function Leaderboard() {
   const [leaders, setLeaders] = useState([]);
@@ -10,17 +56,16 @@ export default function Leaderboard() {
   const walletRef = useRef('');
   const mountedRef = useRef(true);
   const timerRef = useRef(null);
-  const REFRESH_MS = 60000;
 
-  const load = async (signal) => {
-    setLoading(true);
+  const load = async (signal, { showSpinner = false } = {}) => {
+    if (showSpinner) setLoading(true);
     try {
       const data = await getLeaderboard({ signal });
       if (!mountedRef.current) return;
       const list = Array.isArray(data?.entries) ? data.entries : [];
       const rows = list.map((u) => ({
         ...u,
-        progress: Math.max(0, Math.min(1, Number(u.progress ?? u.levelProgress ?? 0))),
+        progress: clampProgress(u.progress ?? u.levelProgress ?? 0),
       }));
       setLeaders(rows);
       setError(null);
@@ -28,7 +73,7 @@ export default function Leaderboard() {
       if (!mountedRef.current) return;
       setError(e?.message || 'Failed to load leaderboard');
     } finally {
-      if (mountedRef.current) setLoading(false);
+      if (mountedRef.current && showSpinner) setLoading(false);
     }
   };
 
@@ -36,8 +81,8 @@ export default function Leaderboard() {
     walletRef.current = localStorage.getItem('wallet') || '';
     mountedRef.current = true;
     const controller = new AbortController();
-    load(controller.signal);
-    timerRef.current = setInterval(() => load(controller.signal), REFRESH_MS);
+    load(controller.signal, { showSpinner: true });
+    timerRef.current = setInterval(() => load(undefined), REFRESH_MS);
     return () => {
       mountedRef.current = false;
       controller.abort();
@@ -45,77 +90,77 @@ export default function Leaderboard() {
     };
   }, []);
 
-  if (loading) return <div className="section">Loading leaderboard…</div>;
-  if (!loading && error)
+  const retry = () => load(undefined, { showSpinner: true });
+
+  if (loading) {
     return (
-      <div className="section error">
-        {error} <button onClick={() => load()}>Retry</button>
-      </div>
+      <Page>
+        <div className="glass-strong lb-fallback">
+          <h2>Loading leaderboard…</h2>
+          <p className="muted">Surfacing the bravest explorers of the Seven Isles.</p>
+        </div>
+      </Page>
     );
+  }
+
+  if (error) {
+    return (
+      <Page>
+        <div className="glass-strong lb-fallback error">
+          <h2>We couldn’t fetch the tides</h2>
+          <p className="muted">{error}</p>
+          <button className="btn ghost" onClick={retry}>
+            Retry
+          </button>
+        </div>
+      </Page>
+    );
+  }
 
   const podium = leaders.slice(0, 3);
   const rest = leaders.slice(3);
 
-  const Bar = ({ pct = 0 }) => (
-    <div className="bar-outer">
-      <div className="bar-inner" style={{ width: `${(pct * 100).toFixed(1)}%` }} />
-    </div>
-  );
-
   return (
     <Page>
-      <section className="section">
-        <div className="hero glass-strong" style={{ marginBottom: 24 }}>
-        <h1>🏆 <span className="yolo-gradient">Cowrie Leaderboard</span></h1>
-        <p className="subtitle">Top explorers across the Seven Isles</p>
-      </div>
+      <section className="section leaderboard-wrapper glass">
+        <header className="lb-header">
+          <h1>
+            🏆 <span className="yolo-gradient">Cowrie Leaderboard</span>
+          </h1>
+          <p className="subtitle">Track the top explorers riding every tide.</p>
+        </header>
 
-      {/* Podium */}
-      <div className="grid podium">
-        {podium.map((u, i) => (
-          <div key={u.wallet || i} className={`card glass podium-${i+1} ${walletRef.current===u.wallet ? 'me' : ''}`}>
-            <div className="corner-rank">#{i+1}</div>
-            <div className="big-wallet">
-              {abbreviateWallet(u.wallet)}
-              {u.twitterHandle ? (
-                <a
-                  className="muted"
-                  style={{ marginLeft: 6 }}
-                  href={`https://x.com/${u.twitterHandle}`}
-                  target="_blank"
-                  rel="noreferrer"
+        <div className="podium">
+          {podium.length === 0 ? (
+            <div className="podium-step ghost">
+              <div className="podium-name muted">No champions yet.</div>
+            </div>
+          ) : (
+            podium.map((u, idx) => {
+              const rank = idx + 1;
+              const isMe = walletRef.current === u.wallet;
+              const badgeSrc = levelBadgeSrc(u.levelName);
+              const xp = Number(u.xp ?? 0).toLocaleString();
+              return (
+                <div
+                  key={u.wallet || rank}
+                  className={`podium-step ${rank === 1 ? 'tall' : ''} ${
+                    isMe ? 'me' : ''
+                  }`}
                 >
-                  @{u.twitterHandle}
-                </a>
-              ) : null}
-            </div>
-            <div className="chips">
-              <span className="chip">{u.tier || 'Free'}</span>
-              <span className="chip">{u.levelName}</span>
-              <span className="chip">{u.xp} XP</span>
-            </div>
-            <Bar pct={u.progress} />
-          </div>
-        ))}
-      </div>
-
-      {/* Rest */}
-      <div className="list">
-        {leaders.length === 0 ? (
-          <div className="muted">No entries yet.</div>
-        ) : (
-          rest.map((u, idx) => {
-            const rank = idx + 4;
-            const isMe = walletRef.current === u.wallet;
-            return (
-              <div key={u.wallet || rank} className={`row glass ${isMe ? 'me' : ''}`}>
-                <div className="rank">#{rank}</div>
-                <div className="wallet mono">
-                  {abbreviateWallet(u.wallet)}
+                  <div className="podium-rank">#{rank}</div>
+                  <img
+                    className="podium-badge"
+                    src={badgeSrc}
+                    alt={u.levelName || 'Level badge'}
+                    onError={(e) => {
+                      e.currentTarget.src = '/images/level-badge.png';
+                    }}
+                  />
+                  <div className="podium-name">{abbreviateWallet(u.wallet)}</div>
                   {u.twitterHandle ? (
                     <a
-                      className="muted"
-                      style={{ marginLeft: 4 }}
+                      className="podium-twitter lb-link"
                       href={`https://x.com/${u.twitterHandle}`}
                       target="_blank"
                       rel="noreferrer"
@@ -123,19 +168,66 @@ export default function Leaderboard() {
                       @{u.twitterHandle}
                     </a>
                   ) : null}
+                  <div className="podium-meta">
+                    <TierBadge tier={u.tier} />
+                    <span className="pill">{u.levelName || 'Shellborn'}</span>
+                    <span className="pill">{xp} XP</span>
+                  </div>
+                  <ProgressMeter progress={u.progress} />
                 </div>
-                <div className="badges">
-                  <span className="chip">{u.tier || 'Free'}</span>
-                  <span className="chip">{u.levelName}</span>
+              );
+            })
+          )}
+        </div>
+
+        <div className="leaderboard-list">
+          {rest.length === 0 ? (
+            <div className="empty">No additional adventurers yet.</div>
+          ) : (
+            rest.map((u, idx) => {
+              const rank = idx + 4;
+              const isMe = walletRef.current === u.wallet;
+              const badgeSrc = levelBadgeSrc(u.levelName);
+              const xp = Number(u.xp ?? 0).toLocaleString();
+              return (
+                <div
+                  key={u.wallet || rank}
+                  className={`leader-card glass ${isMe ? 'me' : ''}`}
+                >
+                  <div className="rank-badge">#{rank}</div>
+                  <img
+                    className="user-badge"
+                    src={badgeSrc}
+                    alt={u.levelName || 'Level badge'}
+                    onError={(e) => {
+                      e.currentTarget.src = '/images/level-badge.png';
+                    }}
+                  />
+                  <div className="user-meta">
+                    <div className="user-line">
+                      {abbreviateWallet(u.wallet)}
+                      {u.twitterHandle ? (
+                        <a
+                          className="lb-link"
+                          href={`https://x.com/${u.twitterHandle}`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          @{u.twitterHandle}
+                        </a>
+                      ) : null}
+                    </div>
+                    <div className="user-line muted">
+                      <TierBadge tier={u.tier} />
+                      <span className="pill">{u.levelName || 'Shellborn'}</span>
+                      <span className="pill">{xp} XP</span>
+                    </div>
+                    <ProgressMeter progress={u.progress} />
+                  </div>
                 </div>
-                <div className="xp mono">{u.xp} XP</div>
-                <div className="grow">
-                  <Bar pct={u.progress} />
-                </div>
-              </div>
-            );
-          })
-        )}
+              );
+            })
+          )}
         </div>
       </section>
     </Page>

--- a/src/pages/Profile.css
+++ b/src/pages/Profile.css
@@ -64,6 +64,7 @@
   background: rgba(0, 19, 51, 0.8);
   padding: 10px;
   box-shadow: 0 0 18px rgba(255, 212, 69, 0.25);
+  animation: floatBadge 6s ease-in-out infinite;
 }
 
 .perk {
@@ -77,6 +78,8 @@
 .profile-info {
   flex: 2;
   min-width: 280px;
+  display: grid;
+  gap: 6px;
 }
 
 .profile-info p {
@@ -97,8 +100,11 @@
 
 .xp-fill {
   height: 100%;
-  background: var(--bar-fill);
+  background: linear-gradient(90deg, #66e0ff, #ffd445, #8b8cff);
+  background-size: 200% 100%;
   transition: width 1s ease-in-out;
+  animation: xpGlow 5.5s ease-in-out infinite;
+  box-shadow: 0 0 16px rgba(102, 224, 255, 0.35);
 }
 
 @keyframes shimmer {
@@ -110,6 +116,25 @@
   font-size: 0.85rem;
   color: #a8c1ff;
   margin-top: 6px;
+}
+
+.proof-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(23, 160, 120, 0.18);
+  color: #8affcb;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border: 1px solid rgba(23, 160, 120, 0.28);
+}
+
+.proof-status.warn {
+  background: rgba(255, 122, 122, 0.12);
+  border-color: rgba(255, 122, 122, 0.28);
+  color: #ffb3b3;
 }
 
 /* ===== Connect buttons row ===== */
@@ -258,6 +283,8 @@
   }
   .profile-info {
     padding-left: 0;
+    text-align: center;
+    justify-items: center;
   }
   .connect-buttons {
     flex-direction: column;
@@ -280,3 +307,30 @@
   animation: skShine 1.2s ease-in-out infinite;
 }
 @keyframes skShine { to { transform: translateX(100%); } }
+
+@keyframes floatBadge {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    box-shadow: 0 0 18px rgba(255, 212, 69, 0.25);
+  }
+  50% {
+    transform: translateY(-6px) rotate(1deg);
+    box-shadow: 0 12px 26px rgba(255, 212, 69, 0.35);
+  }
+  100% {
+    transform: translateY(0) rotate(0deg);
+    box-shadow: 0 0 18px rgba(255, 212, 69, 0.25);
+  }
+}
+
+@keyframes xpGlow {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -6,7 +6,7 @@ import Page from "../components/Page";
 import { API_BASE, API_URLS, getMe } from "../utils/api";
 import { ensureWalletBound } from "../utils/walletBind";
 import WalletConnect from "../components/WalletConnect";
-import { burstConfetti } from "../utils/confetti";
+import { burstConfetti } from '../utils/confetti';
 import ConnectButtons from "../components/ConnectButtons";
 import { useWallet } from "../hooks/useWallet";
 

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -140,6 +140,33 @@ export default function Profile() {
     discord: false,
   });
 
+  const referralCount = useMemo(() => {
+    if (typeof me?.referralCount === 'number') return me.referralCount;
+    if (me?.referral_count != null) return Number(me.referral_count) || 0;
+    if (me?.referralStats && typeof me.referralStats.count === 'number') {
+      return me.referralStats.count;
+    }
+    if (me?.referral_stats && typeof me.referral_stats.count === 'number') {
+      return me.referral_stats.count;
+    }
+    if (Array.isArray(me?.referrals)) return me.referrals.length;
+    if (Array.isArray(me?.referralHistory)) return me.referralHistory.length;
+    return 0;
+  }, [me]);
+
+  const xpProgress = useMemo(() => {
+    const raw = level.progress ?? me?.levelProgress ?? 0;
+    return Math.max(0, Math.min(1, Number(raw) || 0));
+  }, [level.progress, me?.levelProgress]);
+
+  const xpPercent = useMemo(() => (xpProgress * 100).toFixed(1), [xpProgress]);
+
+  const xpTarget = useMemo(() => {
+    if (me?.nextXP != null) return me.nextXP;
+    if (level.nextXP != null) return level.nextXP;
+    return '∞';
+  }, [me?.nextXP, level.nextXP]);
+
   // Prefer connected wallet address; fallback to any stored value on load
   useEffect(() => {
     if (tonWallet && tonWallet !== address) {
@@ -420,13 +447,16 @@ export default function Profile() {
                 <div
                   className="xp-fill"
                   style={{
-                    width: `${((me.levelProgress || 0) * 100).toFixed(1)}%`,
-                    transition: "width 0.8s ease-in-out",
+                    width: `${xpPercent}%`,
                   }}
                 />
               </div>
               <p className="progress-label">
-                {((me.levelProgress || 0) * 100).toFixed(1)}% — XP {me.xp} / {me.nextXP}
+                {xpPercent}% — XP {me.xp ?? 0} / {xpTarget}
+              </p>
+
+              <p>
+                <strong>Referrals:</strong> {referralCount}
               </p>
 
               <button className="connect-btn" style={{ marginTop: 8 }} onClick={() => loadMe()}>
@@ -459,6 +489,7 @@ export default function Profile() {
                     ) : (
                       <span className="connected" style={{ color: 'var(--c-mint)', fontWeight: 800 }}>✅ Connected</span>
                     )}
+                    <span className="proof-status">Proof linked</span>
                     <div className="social-actions">
                       <button className="mini" disabled title="Already connected">Connect</button>
                     </div>
@@ -466,6 +497,7 @@ export default function Profile() {
                 ) : (
                   <>
                     <span className="not-connected">❌ Not Connected</span>
+                    <span className="proof-status warn">Proof pending</span>
                     <div className="social-actions">
                       <button
                         className="mini"
@@ -497,6 +529,7 @@ export default function Profile() {
                     ) : (
                       <span className="connected" style={{ color: 'var(--c-mint)', fontWeight: 800 }}>✅ Connected</span>
                     )}
+                    <span className="proof-status">Proof linked</span>
                     <div className="social-actions">
                       <button className="mini" disabled title="Already connected">Connect</button>
                     </div>
@@ -504,6 +537,7 @@ export default function Profile() {
                 ) : (
                   <>
                     <span className="not-connected">❌ Not Connected</span>
+                    <span className="proof-status warn">Proof pending</span>
                     <div className="social-actions">
                       <button
                         className="mini"
@@ -522,7 +556,10 @@ export default function Profile() {
                 <span className="muted">Discord:</span>
                 {discordConnected ? (
                   <>
-                    <span style={{ color: 'var(--c-mint)', fontWeight: 800 }}>✅ {discord}</span>
+                    <span className="connected" style={{ color: 'var(--c-mint)', fontWeight: 800 }}>
+                      ✅ {discord || 'Connected'}
+                    </span>
+                    <span className="proof-status">Proof linked</span>
                     <div className="social-actions">
                       {discord ? (
                         <button
@@ -543,6 +580,7 @@ export default function Profile() {
                 ) : (
                   <>
                     <span className="not-connected">❌ Not Connected</span>
+                    <span className="proof-status warn">Proof pending</span>
                     <div className="social-actions">
                       <button
                         className="mini"

--- a/src/pages/Quests.css
+++ b/src/pages/Quests.css
@@ -152,6 +152,12 @@
   box-shadow: 0 16px 40px rgba(0,0,0,.35);
 }
 
+.proof-note {
+  font-size: 0.75rem;
+  color: rgba(173, 195, 224, 0.9);
+  margin: 0 0 6px;
+}
+
 .q-row {
   display: flex;
   align-items: center;
@@ -231,6 +237,20 @@
   background: linear-gradient(180deg, rgba(60, 190, 110, .22), rgba(60, 190, 110, .15));
   border-color: rgba(60, 190, 110, .45);
   color: #c7ffd8;
+}
+
+.q-fallback {
+  margin: clamp(48px, 12vw, 96px) auto;
+  padding: clamp(24px, 6vw, 48px);
+  border-radius: 20px;
+  max-width: 480px;
+  text-align: center;
+  display: grid;
+  gap: 12px;
+}
+
+.q-fallback.error {
+  border: 1px solid rgba(255, 106, 106, 0.35);
 }
 
 .actions {

--- a/src/pages/Quests.jsx
+++ b/src/pages/Quests.jsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useState, useRef } from 'react';
-import { getQuests, claimQuest, getMe } from '../utils/api';
+import React, { useEffect, useState, useRef, useMemo } from 'react';
+import {
+  getQuests,
+  claimQuest,
+  getMe,
+  claimSubscriptionReward,
+  claimReferralReward,
+} from '../utils/api';
 import Toast from '../components/Toast';
 import ProfileWidget from '../components/ProfileWidget';
 import QuestCard from '../components/QuestCard';
@@ -8,13 +14,14 @@ import './Quests.css';
 import '../App.css';
 import { burstConfetti } from '../utils/confetti';
 import { useWallet } from '../hooks/useWallet';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 export default function Quests() {
   const [quests, setQuests] = useState([]);
-  const [xp, setXp] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [claiming, setClaiming] = useState({});
+  const [blockedClaims, setBlockedClaims] = useState({});
   const [toast, setToast] = useState('');
   const [activeTab, setActiveTab] = useState('all');
   const [me, setMe] = useState(null);
@@ -31,8 +38,23 @@ export default function Quests() {
   async function loadQuests(signal) {
     const data = await getQuests({ signal });
     if (!mountedRef.current) return;
-    setQuests(data?.quests ?? []);
-    setXp(data?.xp ?? 0);
+    const items = data?.quests ?? [];
+    setQuests(items);
+    setBlockedClaims((prev) => {
+      if (!prev || Object.keys(prev).length === 0) return prev;
+      let mutated = false;
+      const next = { ...prev };
+      items.forEach((quest) => {
+        if (!quest || !next[quest.id]) return;
+        const status = String(quest.proofStatus || quest.proof_status || '').toLowerCase();
+        const finished = quest.completed || quest.claimed || quest.alreadyClaimed;
+        if (finished || status === 'approved') {
+          mutated = true;
+          delete next[quest.id];
+        }
+      });
+      return mutated ? next : prev;
+    });
   }
 
   async function loadMe() {
@@ -81,92 +103,187 @@ export default function Quests() {
     };
   }, []);
 
-    const handleClaim = async (id) => {
-      if (!isConnected) {
-        setToast('Connect your wallet to claim quests');
-        setTimeout(() => setToast(''), 3000);
+  const detectSpecialClaimType = (quest) => {
+    if (!quest || typeof quest !== 'object') return null;
+    const pathy = [
+      quest.claimType,
+      quest.claim_type,
+      quest?.claim?.type,
+      quest?.action?.type,
+      quest?.actionType,
+    ]
+      .filter(Boolean)
+      .map((v) => String(v).toLowerCase());
+    const requirement = String(quest.requirement || quest.gate || '').toLowerCase();
+    const slug = String(quest.slug || quest.code || '').toLowerCase();
+    const tags = Array.isArray(quest.tags)
+      ? quest.tags.map((tag) => String(tag).toLowerCase())
+      : [];
+
+    const isSubscription =
+      pathy.some((p) => p.includes('subscription')) ||
+      requirement.includes('subscription') ||
+      tags.includes('subscription') ||
+      slug.includes('subscription');
+
+    const isReferral =
+      pathy.some((p) => p.includes('referral')) ||
+      requirement.includes('referral') ||
+      tags.includes('referral') ||
+      slug.includes('referral');
+
+    if (isSubscription) return 'subscription';
+    if (isReferral) return 'referral';
+    return null;
+  };
+
+  const handleClaim = async (questLike) => {
+    const quest =
+      typeof questLike === 'object' && questLike
+        ? questLike
+        : quests.find((entry) => entry.id === questLike);
+    const id = quest?.id ?? questLike;
+    if (!id) return;
+
+    if (!isConnected) {
+      setToast('Connect your wallet to claim quests');
+      setTimeout(() => setToast(''), 3000);
+      return;
+    }
+    if (claiming[id]) return;
+
+    setClaiming((c) => ({ ...c, [id]: true }));
+    setBlockedClaims((prev) => ({ ...prev, [id]: undefined }));
+
+    try {
+      const special = detectSpecialClaimType(quest);
+      let res;
+
+      if (special === 'subscription') {
+        res = await claimSubscriptionReward({ questId: id });
+      } else if (special === 'referral') {
+        res = await claimReferralReward({ questId: id });
+      } else {
+        res = await claimQuest(id);
+      }
+
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('claim_clicked', id, res);
+      }
+
+      const errorCode = String(res?.error || res?.code || '').toLowerCase();
+      if (errorCode === 'proof-required' || errorCode === 'proof_required') {
+        setBlockedClaims((prev) => ({ ...prev, [id]: 'proof-required' }));
+        setToast('Submit proof to claim this quest');
         return;
       }
-      if (claiming[id]) return;
-      setClaiming((c) => ({ ...c, [id]: true }));
-      try {
-        const res = await claimQuest(id);
-        if (process.env.NODE_ENV !== 'production') {
-          console.log('claim_clicked', id, res);
-        }
-        burstConfetti();
-        const delta = res?.xpDelta ?? res?.xp;
-        setToast(delta != null ? `+${delta} XP` : 'Quest claimed');
-        await Promise.all([getMe(), getQuests()]).then(([meData, questsData]) => {
-          if (mountedRef.current) {
-            setMe(meData);
-            setQuests(questsData?.quests ?? []);
-            setXp(questsData?.xp ?? 0);
-          }
+
+      burstConfetti();
+      const delta = res?.xpDelta ?? res?.xp;
+      setToast(delta != null ? `+${delta} XP` : 'Quest claimed');
+
+      const [meData, questsData] = await Promise.all([getMe(), getQuests()]);
+      if (mountedRef.current) {
+        setMe(meData);
+        const items = questsData?.quests ?? [];
+        setQuests(items);
+        setBlockedClaims((prev) => {
+          if (!prev || !prev[id]) return prev;
+          const next = { ...prev };
+          delete next[id];
+          return next;
         });
-        window.dispatchEvent(new Event('profile-updated'));
-      } catch (e) {
-        setToast(e.message || 'Failed to claim quest');
-      } finally {
-        setClaiming((c) => ({ ...c, [id]: false }));
-        setTimeout(() => setToast(''), 3000);
       }
-    };
+    } catch (e) {
+      const msg = e?.message || '';
+      if (msg.toLowerCase().includes('proof-required')) {
+        setBlockedClaims((prev) => ({ ...prev, [id]: 'proof-required' }));
+        setToast('Submit proof to claim this quest');
+      } else {
+        setToast(msg || 'Failed to claim quest');
+      }
+    } finally {
+      setClaiming((c) => ({ ...c, [id]: false }));
+      setTimeout(() => setToast(''), 3000);
+    }
+  };
 
-  const shownQuests =
-    activeTab === 'all'
-      ? quests.filter((q) => q.active === 1)
-      : quests.filter(
-          (q) =>
-            (q.category || 'All').toLowerCase() === activeTab && q.active === 1
-        );
+  const tabs = useMemo(
+    () => ['all', 'daily', 'social', 'partner', 'insider', 'onchain'],
+    []
+  );
 
+  const shownQuests = useMemo(
+    () =>
+      activeTab === 'all'
+        ? quests.filter((q) => q.active === 1)
+        : quests.filter(
+            (q) =>
+              (q.category || 'All').toLowerCase() === activeTab && q.active === 1
+          ),
+    [activeTab, quests]
+  );
+  if (loading)
+    return (
+      <Page>
+        <div className="glass-strong q-fallback">
+          <h2>Loading quests…</h2>
+          <p className="muted">Summoning the Seven Isles challenges.</p>
+        </div>
+      </Page>
+    );
 
-  if (loading) return <div className="loading">Loading quests…</div>;
   if (!loading && error)
     return (
-      <div className="error">
-        {error} <button onClick={sync}>Retry</button>
-      </div>
+      <Page>
+        <div className="glass-strong q-fallback error">
+          <h2>We can’t load quests right now</h2>
+          <p className="muted">{error}</p>
+          <button className="btn ghost" onClick={sync}>
+            Retry
+          </button>
+        </div>
+      </Page>
     );
 
   return (
     <Page>
-      <div className="q-container">
-        <div className="glass profile-strip">
-          <ProfileWidget />
-        </div>
-
-        <div className="glass-strong q-header">
-          <div className="q-title">
-            <span className="emoji">📜</span>
-            <h1><span className="yolo-gradient">Quests</span></h1>
+      <ErrorBoundary>
+        <div className="q-container">
+          <div className="glass profile-strip">
+            <ProfileWidget />
           </div>
-          <p className="subtitle">Complete tasks. Earn XP. Level up.</p>
-          <div className="tabs">
-            {['all','daily','social','partner','insider','onchain'].map((type) => (
-              <button
-                key={type}
-                className={`tab ${activeTab === type ? 'active' : ''}`}
-                onClick={() => setActiveTab(type)}
-              >
-                {type === 'all' && 'All Quests'}
-                {type === 'daily' && '📅 Daily'}
-                {type === 'social' && '🌐 Social'}
-                {type === 'partner' && '🤝 Partner'}
-                {type === 'insider' && '🧠 Insider'}
-                {type === 'onchain' && '🧾 Onchain'}
-              </button>
-            ))}
-          </div>
-        </div>
 
-        <div className="q-list">
-          {shownQuests.length === 0 ? (
-            <div className="glass quest-card">
-              <p className="quest-title">No quests yet for this category.</p>
+          <div className="glass-strong q-header">
+            <div className="q-title">
+              <span className="emoji">📜</span>
+              <h1><span className="yolo-gradient">Quests</span></h1>
             </div>
-          ) : (
+            <p className="subtitle">Complete tasks. Earn XP. Level up.</p>
+            <div className="tabs">
+              {tabs.map((type) => (
+                <button
+                  key={type}
+                  className={`tab ${activeTab === type ? 'active' : ''}`}
+                  onClick={() => setActiveTab(type)}
+                >
+                  {type === 'all' && 'All Quests'}
+                  {type === 'daily' && '📅 Daily'}
+                  {type === 'social' && '🌐 Social'}
+                  {type === 'partner' && '🤝 Partner'}
+                  {type === 'insider' && '🧠 Insider'}
+                  {type === 'onchain' && '🧾 Onchain'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="q-list">
+            {shownQuests.length === 0 ? (
+              <div className="glass quest-card">
+                <p className="quest-title">No quests yet for this category.</p>
+              </div>
+            ) : (
               shownQuests.map((q) => (
                 <QuestCard
                   key={q.id}
@@ -176,13 +293,15 @@ export default function Quests() {
                   claiming={!!claiming[q.id]}
                   setToast={setToast}
                   canClaim={isConnected}
+                  blockedReason={blockedClaims[q.id]}
                 />
               ))
             )}
-        </div>
+          </div>
 
-        <Toast message={toast} />
-      </div>
+          <Toast message={toast} />
+        </div>
+      </ErrorBoundary>
     </Page>
   );
 }

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -127,6 +127,42 @@ describe('Quests page claiming', () => {
     expect(claimBtn).toBeDisabled();
     expect(claimBtn).toHaveAttribute('title', 'Connect wallet to claim');
   });
+
+  test('proof-required error disables claim until proof submitted', async () => {
+    getQuests.mockResolvedValueOnce({
+      quests: [
+        {
+          id: 1,
+          xp: 25,
+          active: 1,
+          requirement: 'none',
+        },
+      ],
+      completed: [],
+      xp: 0,
+    });
+    getMe.mockResolvedValueOnce({
+      wallet: 'w',
+      xp: 0,
+      level: '1',
+      levelProgress: 0,
+      socials: {},
+    });
+
+    render(<Quests />);
+
+    const claimBtn = await screen.findByRole('button', { name: 'Claim' });
+    claimQuest.mockResolvedValueOnce({ error: 'proof-required' });
+
+    await userEvent.click(claimBtn);
+
+    await waitFor(() => expect(claimQuest).toHaveBeenCalled());
+
+    const disabledBtn = await screen.findByRole('button', { name: 'Claim' });
+    expect(disabledBtn).toBeDisabled();
+    expect(disabledBtn).toHaveAttribute('title', 'Submit proof before claiming');
+    expect(screen.getByText(/Proof required/i)).toBeInTheDocument();
+  });
 });
 
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -187,6 +187,34 @@ export function claimQuest(id, opts = {}) {
   });
 }
 
+export function claimSubscriptionReward({ questId } = {}, opts = {}) {
+  return postJSON(
+    '/api/v1/subscription/claim',
+    questId ? { questId } : {},
+    opts
+  ).then((res) => {
+    clearUserCache();
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('profile-updated'));
+    }
+    return res;
+  });
+}
+
+export function claimReferralReward({ questId } = {}, opts = {}) {
+  return postJSON(
+    '/api/referral/claim',
+    questId ? { questId } : {},
+    opts
+  ).then((res) => {
+    clearUserCache();
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('profile-updated'));
+    }
+    return res;
+  });
+}
+
 export function submitProof(id, { url }, opts = {}) {
   return postJSON(`/api/quests/${id}/proofs`, { url }, opts).then((res) => {
     clearUserCache();
@@ -277,6 +305,8 @@ export const api = {
   startDiscord,
   startTwitter,
   claimQuest,
+  claimSubscriptionReward,
+  claimReferralReward,
   submitProof,
   clearUserCache,
   getReferralInfo,


### PR DESCRIPTION
## Summary
- handle proof-required gating and new claim endpoints on quests with updated error fallback
- enrich the explorer profile with referral stats, proof-linked badges, and animated progress visuals
- redesign the leaderboard podium and responsive list with tier badges and mobile-friendly layout
- refresh the sidebar styling to match the oceanic navigation theme

## Testing
- CI=1 npm test -- Quests.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8b3d7f1fc832ba1562347d720b1eb