### PR TITLE
Harden quest claiming flow

### DIFF
--- a/src/components/QuestCard.js
+++ b/src/components/QuestCard.js
@@ -2,6 +2,9 @@ import React, { useState, useRef } from 'react';
 import useTilt from '../fx/useTilt';
 import { submitProof, tierMultiplier } from '../utils/api';
 
+const PROOF_REQUIRED = 'proof-required';
+const TOAST_RESET_MS = process.env.NODE_ENV === 'test' ? 0 : 3000;
+
 export default function QuestCard({
   quest,
   onClaim,
@@ -10,11 +13,15 @@ export default function QuestCard({
   setToast,
   canClaim = true,
   blockedReason,
+  onProofStatusChange,
 }) {
   const q = quest;
-  const needsProof = q.requirement && q.requirement !== 'none';
+  const baseNeedsProof = q.requirement && q.requirement !== 'none';
+  const needsProof = baseNeedsProof || blockedReason === PROOF_REQUIRED;
   const alreadyClaimed = q.completed || q.alreadyClaimed || q.claimed;
-  const claimable = !alreadyClaimed && (!needsProof || q.proofStatus === 'approved');
+  const proofStatus = String(q.proofStatus || q.proof_status || '').toLowerCase();
+  const claimable =
+    !alreadyClaimed && (!baseNeedsProof || proofStatus === 'approved');
   const [url, setUrl] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const mult = tierMultiplier(me?.tier || me?.subscriptionTier);
@@ -22,9 +29,12 @@ export default function QuestCard({
   const cardRef = useRef(null);
   useTilt(cardRef, 8);
   const isBlocked = Boolean(blockedReason);
-  const blockedTooltip = blockedReason === 'proof-required'
+  const proofBlocked = blockedReason === PROOF_REQUIRED;
+  const blockedTooltip = proofBlocked
     ? 'Submit proof before claiming'
     : blockedReason || '';
+  const proofNoteId = `proof-note-${q.id}`;
+  const buttonDisabled = claiming || !claimable || !canClaim || isBlocked;
 
   return (
     <div ref={cardRef} className="glass quest-card fade-in">
@@ -37,7 +47,7 @@ export default function QuestCard({
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             {alreadyClaimed ? (
               <span className="chip completed">✅ Completed</span>
-            ) : q.proofStatus === 'pending' ? (
+            ) : proofStatus === 'pending' ? (
               <span className="chip pending">🕒 Pending review</span>
             ) : null}
           <span className="xp-badge">
@@ -95,13 +105,15 @@ export default function QuestCard({
               setSubmitting(true);
               try {
                 const res = await submitProof(q.id, { url });
-                q.proofStatus = res?.status || 'pending'; // optimistic
+                const status = String(res?.status || 'pending').toLowerCase();
+                q.proofStatus = status; // optimistic
+                onProofStatusChange?.({ questId: q.id, status });
                 setToast?.('Proof submitted');
-                setTimeout(() => setToast?.(''), 3000);
+                setTimeout(() => setToast?.(''), TOAST_RESET_MS);
                 window.dispatchEvent(new Event('profile-updated'));
               } catch (e) {
                 setToast?.(e?.message || 'Failed to submit proof');
-                setTimeout(() => setToast?.(''), 3000);
+                setTimeout(() => setToast?.(''), TOAST_RESET_MS);
               } finally {
                 setSubmitting(false);
               }
@@ -117,23 +129,28 @@ export default function QuestCard({
           <button className="btn success" disabled>Claimed</button>
         ) : (
           <>
-            {isBlocked && blockedReason === 'proof-required' ? (
-              <p className="muted proof-note">Proof required — submit your link above.</p>
+            {isBlocked && proofBlocked ? (
+              <p id={proofNoteId} className="muted proof-note" role="note">
+                Proof required — submit your link above.
+              </p>
             ) : null}
             <button
               className="btn ghost"
               onClick={() => onClaim?.(q)}
-              disabled={claiming || !claimable || !canClaim || isBlocked}
+              disabled={buttonDisabled}
               title={
                 !canClaim
                   ? 'Connect wallet to claim'
+                  : proofBlocked
+                  ? blockedTooltip
                   : isBlocked
                   ? blockedTooltip
                   : !claimable && needsProof
                   ? 'Submit proof first'
                   : ''
               }
-              aria-disabled={claiming || !claimable || !canClaim || isBlocked}
+              aria-disabled={buttonDisabled}
+              aria-describedby={proofBlocked ? proofNoteId : undefined}
             >
               {claiming ? 'Claiming...' : 'Claim'}
             </button>

--- a/src/lib/claimType.js
+++ b/src/lib/claimType.js
@@ -1,0 +1,52 @@
+const SUBSCRIPTION_KEYWORDS = ['subscription', 'subscribe', 'subscriber'];
+const REFERRAL_KEYWORDS = ['referral', 'refer', 'invite', 'invitation', 'referrer'];
+
+function pushValue(acc, value) {
+  if (value == null) return;
+  if (Array.isArray(value)) {
+    value.forEach((entry) => pushValue(acc, entry));
+    return;
+  }
+  if (typeof value === 'object') {
+    Object.values(value).forEach((entry) => pushValue(acc, entry));
+    return;
+  }
+  const text = String(value).trim().toLowerCase();
+  if (text) acc.push(text);
+}
+
+export function detectSpecialClaimType(quest) {
+  if (!quest || typeof quest !== 'object') return null;
+  const haystack = [];
+
+  pushValue(haystack, quest.claimType);
+  pushValue(haystack, quest.claim_type);
+  pushValue(haystack, quest?.claim?.type);
+  pushValue(haystack, quest?.action?.type);
+  pushValue(haystack, quest?.actionType);
+  pushValue(haystack, quest?.action?.category);
+  pushValue(haystack, quest.requirement);
+  pushValue(haystack, quest.requirement_type);
+  pushValue(haystack, quest.requirementType);
+  pushValue(haystack, quest.requirements);
+  pushValue(haystack, quest.gate);
+  pushValue(haystack, quest.slug);
+  pushValue(haystack, quest.code);
+  pushValue(haystack, quest.type);
+  pushValue(haystack, quest.title);
+  pushValue(haystack, quest.tags);
+
+  const isSubscription = haystack.some((entry) =>
+    SUBSCRIPTION_KEYWORDS.some((keyword) => entry.includes(keyword))
+  );
+  if (isSubscription) return 'subscription';
+
+  const isReferral = haystack.some((entry) =>
+    REFERRAL_KEYWORDS.some((keyword) => entry.includes(keyword))
+  );
+  if (isReferral) return 'referral';
+
+  return null;
+}
+
+export default detectSpecialClaimType;

--- a/src/pages/Quests.jsx
+++ b/src/pages/Quests.jsx
@@ -15,6 +15,33 @@ import '../App.css';
 import { burstConfetti } from '../utils/confetti';
 import { useWallet } from '../hooks/useWallet';
 import ErrorBoundary from '../components/ErrorBoundary';
+import { detectSpecialClaimType } from '../lib/claimType';
+
+const PROOF_REQUIRED = 'proof-required';
+const TOAST_DISMISS_MS = process.env.NODE_ENV === 'test' ? 0 : 3000;
+
+function normalizeStatus(status) {
+  return String(status || '').toLowerCase();
+}
+
+function isProofRequired(value) {
+  const text = String(value || '').toLowerCase();
+  return text.includes('proof-required') || text.includes('proof_required');
+}
+
+function responseRequiresProof(res) {
+  if (!res) return false;
+  if (typeof res === 'string') return isProofRequired(res);
+  if (res instanceof Error) return isProofRequired(res.message);
+  if (typeof res === 'object') {
+    return (
+      isProofRequired(res.error) ||
+      isProofRequired(res.code) ||
+      isProofRequired(res.message)
+    );
+  }
+  return false;
+}
 
 export default function Quests() {
   const [quests, setQuests] = useState([]);
@@ -35,7 +62,7 @@ export default function Quests() {
     };
   }, []);
 
-  const loadQuests = useCallback(async (signal) => {
+  const loadQuests = useCallback(async ({ signal } = {}) => {
     const data = await getQuests({ signal });
     if (!mountedRef.current) return;
     const items = data?.quests ?? [];
@@ -46,7 +73,7 @@ export default function Quests() {
       const next = { ...prev };
       items.forEach((quest) => {
         if (!quest || !next[quest.id]) return;
-        const status = String(quest.proofStatus || quest.proof_status || '').toLowerCase();
+        const status = normalizeStatus(quest.proofStatus || quest.proof_status);
         const finished = quest.completed || quest.claimed || quest.alreadyClaimed;
         if (finished || status === 'approved') {
           mutated = true;
@@ -57,25 +84,25 @@ export default function Quests() {
     });
   }, []);
 
-  const loadMe = useCallback(async () => {
+  const loadMe = useCallback(async (opts = {}) => {
     try {
-      const data = await getMe();
+      const data = await getMe(opts);
       if (mountedRef.current) setMe(data);
     } catch {}
   }, []);
 
-  const sync = useCallback(async () => {
-    setLoading(true);
+  const sync = useCallback(async ({ background } = {}) => {
+    if (!background) setLoading(true);
     const controller = new AbortController();
     try {
-      await loadQuests(controller.signal);
+      await loadQuests({ signal: controller.signal });
       if (mountedRef.current) setError(null);
     } catch (e) {
       if (!mountedRef.current) return;
       setError(e?.message || 'Failed to load quests. Please try again.');
       console.error('[Quests] load error:', e);
     } finally {
-      if (mountedRef.current) setLoading(false);
+      if (!background && mountedRef.current) setLoading(false);
     }
   }, [loadQuests]);
 
@@ -92,8 +119,8 @@ export default function Quests() {
 
   useEffect(() => {
     const reload = () => {
-      loadMe();
-      sync();
+      loadMe({ force: true });
+      sync({ background: true });
     };
     window.addEventListener('profile-updated', reload);
     window.addEventListener('focus', reload);
@@ -148,13 +175,18 @@ export default function Quests() {
 
       if (!isConnected) {
         setToast('Connect your wallet to claim quests');
-        setTimeout(() => setToast(''), 3000);
+        setTimeout(() => setToast(''), TOAST_DISMISS_MS);
         return;
       }
       if (claiming[id]) return;
 
       setClaiming((c) => ({ ...c, [id]: true }));
-      setBlockedClaims((prev) => ({ ...prev, [id]: undefined }));
+      setBlockedClaims((prev) => {
+        if (!prev || !prev[id]) return prev;
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
 
       try {
         const special = detectSpecialClaimType(quest);
@@ -172,9 +204,8 @@ export default function Quests() {
           console.log('claim_clicked', id, res);
         }
 
-        const errorCode = String(res?.error || res?.code || '').toLowerCase();
-        if (errorCode === 'proof-required' || errorCode === 'proof_required') {
-          setBlockedClaims((prev) => ({ ...prev, [id]: 'proof-required' }));
+        if (responseRequiresProof(res)) {
+          setBlockedClaims((prev) => ({ ...prev, [id]: PROOF_REQUIRED }));
           setToast('Submit proof to claim this quest');
           return;
         }
@@ -183,38 +214,58 @@ export default function Quests() {
         const delta = res?.xpDelta ?? res?.xp;
         setToast(delta != null ? `+${delta} XP` : 'Quest claimed');
 
-        const [meData, questsData] = await Promise.all([getMe(), getQuests()]);
-        if (mountedRef.current) {
-          setMe(meData);
-          const items = questsData?.quests ?? [];
-          setQuests(items);
-          setBlockedClaims((prev) => {
-            if (!prev || !prev[id]) return prev;
-            const next = { ...prev };
-            delete next[id];
-            return next;
-          });
-        }
+        await Promise.all([loadMe({ force: true }), loadQuests()]);
+        setBlockedClaims((prev) => {
+          if (!prev || !prev[id]) return prev;
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
       } catch (e) {
         const msg = e?.message || '';
-        if (msg.toLowerCase().includes('proof-required')) {
-          setBlockedClaims((prev) => ({ ...prev, [id]: 'proof-required' }));
+        if (responseRequiresProof(e)) {
+          setBlockedClaims((prev) => ({ ...prev, [id]: PROOF_REQUIRED }));
           setToast('Submit proof to claim this quest');
         } else {
           setToast(msg || 'Failed to claim quest');
         }
       } finally {
         setClaiming((c) => ({ ...c, [id]: false }));
-        setTimeout(() => setToast(''), 3000);
+        setTimeout(() => setToast(''), TOAST_DISMISS_MS);
       }
     },
-    [claiming, detectSpecialClaimType, isConnected, quests]
+    [claiming, isConnected, quests, loadMe, loadQuests]
   );
 
   const tabs = useMemo(
     () => ['all', 'daily', 'social', 'partner', 'insider', 'onchain'],
     []
   );
+
+  const handleProofStatusChange = useCallback(({ questId, status }) => {
+    if (!questId) return;
+    const normalized = normalizeStatus(status);
+    setQuests((prev) => {
+      if (!Array.isArray(prev) || prev.length === 0) return prev;
+      let mutated = false;
+      const next = prev.map((quest) => {
+        if (!quest || quest.id !== questId) return quest;
+        const current = normalizeStatus(quest.proofStatus || quest.proof_status);
+        if (current === normalized) return quest;
+        mutated = true;
+        return { ...quest, proofStatus: normalized };
+      });
+      return mutated ? next : prev;
+    });
+    if (normalized === 'approved') {
+      setBlockedClaims((prev) => {
+        if (!prev || !prev[questId]) return prev;
+        const next = { ...prev };
+        delete next[questId];
+        return next;
+      });
+    }
+  }, []);
 
   const shownQuests = useMemo(
     () =>
@@ -296,7 +347,8 @@ export default function Quests() {
                   claiming={!!claiming[q.id]}
                   setToast={setToast}
                   canClaim={isConnected}
-                  blockedReason={blockedClaims[q.id]}
+                  blockedReason={blockedClaims?.[q.id]}
+                  onProofStatusChange={handleProofStatusChange}
                 />
               ))
             )}

--- a/src/pages/Quests.test.js
+++ b/src/pages/Quests.test.js
@@ -1,115 +1,274 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Quests from './Quests';
-import { getQuests, claimQuest, getMe, submitProof } from '../utils/api';
+import {
+  getQuests,
+  claimQuest,
+  getMe,
+  submitProof,
+  claimSubscriptionReward,
+  claimReferralReward,
+} from '../utils/api';
 import { useWallet } from '../hooks/useWallet';
+import { detectSpecialClaimType } from '../lib/claimType';
 
 jest.mock('../utils/api');
 jest.mock('../hooks/useWallet', () => ({
   useWallet: jest.fn(),
 }));
 
+const baseProfile = {
+  wallet: 'w',
+  xp: 0,
+  level: '1',
+  levelProgress: 0,
+  socials: {},
+};
+
+describe('detectSpecialClaimType helper', () => {
+  test('detects subscription metadata across fields', () => {
+    expect(
+      detectSpecialClaimType({
+        claimType: 'Subscription_bonus',
+        tags: ['exclusive'],
+      })
+    ).toBe('subscription');
+
+    expect(
+      detectSpecialClaimType({
+        tags: ['Subscribe'],
+        requirement: 'join_subscription',
+      })
+    ).toBe('subscription');
+  });
+
+  test('detects referral metadata and ignores other quests', () => {
+    expect(
+      detectSpecialClaimType({
+        action: { type: 'REFERRAL_reward' },
+        slug: 'invite-a-friend',
+        tags: [{ label: 'friends' }],
+      })
+    ).toBe('referral');
+
+    expect(detectSpecialClaimType({ claimType: 'standard' })).toBeNull();
+  });
+});
+
 describe('Quests page claiming', () => {
   beforeEach(() => {
+    jest.useFakeTimers('modern');
     jest.clearAllMocks();
     localStorage.clear();
     useWallet.mockReturnValue({ wallet: 'w', isConnected: true });
+    getMe.mockResolvedValue(baseProfile);
+    getQuests.mockResolvedValue({ quests: [], completed: [], xp: 0 });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   test('claiming a quest refreshes data and shows awarded XP', async () => {
-    getQuests.mockResolvedValueOnce({
-      quests: [{ id: 1, xp: 10, active: 1, requirement: 'none' }],
-      completed: [],
-      xp: 0,
-    });
-    getMe.mockResolvedValueOnce({
-      wallet: 'w',
-      xp: 0,
-      level: '1',
-      levelProgress: 0,
-      socials: {},
-    });
+    const quest = { id: 1, xp: 10, active: 1, requirement: 'none' };
+    getQuests.mockResolvedValueOnce({ quests: [quest], completed: [], xp: 0 });
+    getMe.mockResolvedValueOnce(baseProfile);
 
     render(<Quests />);
+    await waitFor(() => expect(getQuests).toHaveBeenCalled());
 
-    const claimBtn = await screen.findByText('Claim');
+    const claimBtn = await screen.findByRole('button', { name: 'Claim' });
 
     claimQuest.mockResolvedValue({ xp: 50 });
-    getMe.mockResolvedValueOnce({
-      wallet: 'w',
-      xp: 50,
-      level: '1',
-      levelProgress: 0,
-      socials: {},
-    });
-    getQuests.mockResolvedValueOnce({
-      quests: [{ id: 1, xp: 10, active: 1, completed: true }],
+    getMe.mockResolvedValue({ ...baseProfile, xp: 50 });
+    getQuests.mockResolvedValue({
+      quests: [{ ...quest, completed: true }],
       completed: [1],
       xp: 50,
     });
 
     await userEvent.click(claimBtn);
 
-    await waitFor(() => expect(getMe).toHaveBeenCalled());
-    await waitFor(() => expect(getQuests).toHaveBeenCalled());
-
+    await waitFor(() => expect(claimQuest).toHaveBeenCalledWith(1));
     expect(await screen.findByText('+50 XP')).toBeInTheDocument();
   });
 
-  test('quest title links to URL when provided', async () => {
-    getQuests.mockResolvedValueOnce({
-      quests: [{ id: 1, xp: 10, active: 1, url: 'https://example.com', requirement: 'none' }],
+  test('subscription quests use the subscription claim endpoint', async () => {
+    const quest = {
+      id: 'sub-1',
+      xp: 40,
+      active: 1,
+      requirement: 'none',
+      claimType: 'subscription_reward',
+    };
+    getQuests.mockResolvedValueOnce({ quests: [quest], completed: [], xp: 0 });
+    getMe.mockResolvedValueOnce(baseProfile);
+
+    render(<Quests />);
+    await waitFor(() => expect(getQuests).toHaveBeenCalled());
+
+    const claimBtn = await screen.findByRole('button', { name: 'Claim' });
+
+    claimSubscriptionReward.mockResolvedValue({ xp: 40 });
+    getMe.mockResolvedValue({ ...baseProfile, xp: 40 });
+    getQuests.mockResolvedValue({
+      quests: [{ ...quest, completed: true }],
+      completed: ['sub-1'],
+      xp: 40,
+    });
+
+    await userEvent.click(claimBtn);
+
+    await waitFor(() =>
+      expect(claimSubscriptionReward).toHaveBeenCalledWith({ questId: 'sub-1' })
+    );
+    expect(claimQuest).not.toHaveBeenCalled();
+    expect(await screen.findByText('+40 XP')).toBeInTheDocument();
+  });
+
+  test('referral quests use the referral claim endpoint', async () => {
+    const quest = {
+      id: 'ref-1',
+      xp: 15,
+      active: 1,
+      requirement: 'none',
+      tags: ['Referral'],
+    };
+    getQuests.mockResolvedValueOnce({ quests: [quest], completed: [], xp: 0 });
+    getMe.mockResolvedValueOnce(baseProfile);
+
+    render(<Quests />);
+    await waitFor(() => expect(getQuests).toHaveBeenCalled());
+
+    const claimBtn = await screen.findByRole('button', { name: 'Claim' });
+
+    claimReferralReward.mockResolvedValue({ xpDelta: 15 });
+    getMe.mockResolvedValue({ ...baseProfile, xp: 15 });
+    getQuests.mockResolvedValue({
+      quests: [{ ...quest, completed: true }],
+      completed: ['ref-1'],
+      xp: 15,
+    });
+
+    await userEvent.click(claimBtn);
+
+    await waitFor(() =>
+      expect(claimReferralReward).toHaveBeenCalledWith({ questId: 'ref-1' })
+    );
+    expect(claimQuest).not.toHaveBeenCalled();
+    expect(await screen.findByText('+15 XP')).toBeInTheDocument();
+  });
+
+  test('proof-required response blocks claim until proof approved', async () => {
+    const quest = {
+      id: 'special',
+      xp: 25,
+      active: 1,
+      requirement: 'none',
+      claimType: 'subscription_reward',
+    };
+    getQuests.mockResolvedValueOnce({ quests: [quest], completed: [], xp: 0 });
+    getMe.mockResolvedValueOnce(baseProfile);
+    getQuests.mockResolvedValue({
+      quests: [{ ...quest, proofStatus: 'approved' }],
       completed: [],
       xp: 0,
     });
-    getMe.mockResolvedValueOnce({
-      wallet: 'w',
-      xp: 0,
-      level: '1',
-      levelProgress: 0,
-      socials: {},
-    });
 
     render(<Quests />);
+    await waitFor(() => expect(getQuests).toHaveBeenCalled());
 
-    const link = await screen.findByRole('link', { name: '1' });
-    expect(link).toHaveAttribute('href', 'https://example.com');
+    const claimBtn = await screen.findByRole('button', { name: 'Claim' });
+
+    claimSubscriptionReward.mockResolvedValueOnce({ error: 'proof_required' });
+
+    await userEvent.click(claimBtn);
+
+    await waitFor(() =>
+      expect(claimSubscriptionReward).toHaveBeenCalledWith({ questId: 'special' })
+    );
+
+    const blockedBtn = await screen.findByRole('button', { name: 'Claim' });
+    expect(blockedBtn).toBeDisabled();
+    expect(blockedBtn).toHaveAttribute('title', 'Submit proof before claiming');
+    const note = screen.getByText('Proof required — submit your link above.');
+    expect(note).toBeInTheDocument();
+    const describedBy = blockedBtn.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    if (describedBy) {
+      const describedEl = document.getElementById(describedBy);
+      expect(describedEl).toHaveTextContent('Proof required — submit your link above.');
+    }
+
+    const input = await screen.findByPlaceholderText('Paste link here');
+    await userEvent.type(input, 'https://example.com/proof');
+    submitProof.mockResolvedValueOnce({ status: 'approved' });
+
+    const submitBtn = screen.getByRole('button', { name: 'Submit' });
+    await userEvent.click(submitBtn);
+
+    await waitFor(() =>
+      expect(submitProof).toHaveBeenCalledWith('special', {
+        url: 'https://example.com/proof',
+      })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Claim' })).not.toBeDisabled()
+    );
+    expect(
+      screen.queryByText('Proof required — submit your link above.')
+    ).not.toBeInTheDocument();
   });
 
   test('submitting proof enables claim for tweet quest', async () => {
-    getQuests.mockResolvedValueOnce({
-      quests: [{ id: 1, xp: 10, active: 1, requirement: 'tweet' }],
+    const quest = { id: 1, xp: 10, active: 1, requirement: 'tweet' };
+    getQuests.mockResolvedValueOnce({ quests: [quest], completed: [], xp: 0 });
+    getMe.mockResolvedValueOnce(baseProfile);
+    getQuests.mockResolvedValue({
+      quests: [{ ...quest, proofStatus: 'approved' }],
       completed: [],
       xp: 0,
-    });
-    getQuests.mockResolvedValueOnce({
-      quests: [
-        { id: 1, xp: 10, active: 1, requirement: 'tweet', proofStatus: 'approved' },
-      ],
-      completed: [],
-      xp: 0,
-    });
-    getMe.mockResolvedValueOnce({
-      wallet: 'w',
-      xp: 0,
-      level: '1',
-      levelProgress: 0,
-      socials: {},
     });
 
     render(<Quests />);
+    await waitFor(() => expect(getQuests).toHaveBeenCalled());
 
     const input = await screen.findByPlaceholderText('Paste tweet/retweet/quote link');
     await userEvent.type(input, 'https://twitter.com/user/status/1');
 
     submitProof.mockResolvedValueOnce({ status: 'approved' });
-      const submitBtn = screen.getByText('Submit');
+    const submitBtn = screen.getByRole('button', { name: 'Submit' });
     await userEvent.click(submitBtn);
 
-    await waitFor(() => expect(submitProof).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(submitProof).toHaveBeenCalledWith(1, {
+        url: 'https://twitter.com/user/status/1',
+      })
+    );
 
-    const claimBtn = await screen.findByText('Claim');
-    expect(claimBtn).not.toBeDisabled();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Claim' })).not.toBeDisabled()
+    );
+  });
+
+  test('quest title links to URL when provided', async () => {
+    const quest = {
+      id: 1,
+      xp: 10,
+      active: 1,
+      requirement: 'none',
+      url: 'https://example.com',
+    };
+    getQuests.mockResolvedValueOnce({ quests: [quest], completed: [], xp: 0 });
+    getMe.mockResolvedValueOnce(baseProfile);
+
+    render(<Quests />);
+    await waitFor(() => expect(getQuests).toHaveBeenCalled());
+
+    const link = await screen.findByRole('link', { name: '1' });
+    expect(link).toHaveAttribute('href', 'https://example.com');
   });
 
   test('claim button disabled when wallet disconnected', async () => {
@@ -122,47 +281,10 @@ describe('Quests page claiming', () => {
     getMe.mockResolvedValueOnce(null);
 
     render(<Quests />);
+    await waitFor(() => expect(getQuests).toHaveBeenCalled());
 
-    const claimBtn = await screen.findByText('Claim');
+    const claimBtn = await screen.findByRole('button', { name: 'Claim' });
     expect(claimBtn).toBeDisabled();
     expect(claimBtn).toHaveAttribute('title', 'Connect wallet to claim');
   });
-
-  test('proof-required error disables claim until proof submitted', async () => {
-    getQuests.mockResolvedValueOnce({
-      quests: [
-        {
-          id: 1,
-          xp: 25,
-          active: 1,
-          requirement: 'none',
-        },
-      ],
-      completed: [],
-      xp: 0,
-    });
-    getMe.mockResolvedValueOnce({
-      wallet: 'w',
-      xp: 0,
-      level: '1',
-      levelProgress: 0,
-      socials: {},
-    });
-
-    render(<Quests />);
-
-    const claimBtn = await screen.findByRole('button', { name: 'Claim' });
-    claimQuest.mockResolvedValueOnce({ error: 'proof-required' });
-
-    await userEvent.click(claimBtn);
-
-    await waitFor(() => expect(claimQuest).toHaveBeenCalled());
-
-    const disabledBtn = await screen.findByRole('button', { name: 'Claim' });
-    expect(disabledBtn).toBeDisabled();
-    expect(disabledBtn).toHaveAttribute('title', 'Submit proof before claiming');
-    expect(screen.getByText(/Proof required/i)).toBeInTheDocument();
-  });
 });
-
-

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -103,6 +103,23 @@ export function clearUserCache() {
   ["quests", "me"].forEach((k) => _cache.delete(userKey(k)));
 }
 
+function normalizeErrorCode(value) {
+  if (value == null) return value;
+  return String(value).trim().toLowerCase().replace(/_/g, '-');
+}
+
+function normalizeResponse(res) {
+  if (!res || typeof res !== 'object') return res;
+  const next = { ...res };
+  if ('error' in next && next.error != null) {
+    next.error = normalizeErrorCode(next.error);
+  }
+  if ('code' in next && next.code != null) {
+    next.code = normalizeErrorCode(next.code);
+  }
+  return next;
+}
+
 export async function jsonFetch(path, opts = {}) {
   const controller = opts.signal ? null : new AbortController();
   const id = controller ? setTimeout(() => controller.abort(), opts.timeout || 15000) : null;
@@ -183,7 +200,7 @@ export function claimQuest(id, opts = {}) {
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new Event('profile-updated'));
     }
-    return res;
+    return normalizeResponse(res);
   });
 }
 
@@ -197,7 +214,7 @@ export function claimSubscriptionReward({ questId } = {}, opts = {}) {
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new Event('profile-updated'));
     }
-    return res;
+    return normalizeResponse(res);
   });
 }
 
@@ -211,7 +228,7 @@ export function claimReferralReward({ questId } = {}, opts = {}) {
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new Event('profile-updated'));
     }
-    return res;
+    return normalizeResponse(res);
   });
 }
 
@@ -221,7 +238,7 @@ export function submitProof(id, { url }, opts = {}) {
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new Event('profile-updated'));
     }
-    return res;
+    return normalizeResponse(res);
   });
 }
 


### PR DESCRIPTION
## Summary
- route subscription and referral quests through their dedicated claim APIs
- block claims on proof-required responses while showing inline messaging and re-enable once proof is approved
- normalize API error codes and add a pure claim type detector with expanded quest tests

## Testing
- `npx jest --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68c903ead4fc832b95c0732e77e9c292