### PR TITLE
feat: unify level progression data

### DIFF
--- a/backend/src/lib/progression.js
+++ b/backend/src/lib/progression.js
@@ -1,0 +1,89 @@
+const clamp01 = (value) => {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  if (n <= 0) return 0;
+  if (n >= 1) return 1;
+  return n;
+};
+
+const LEVELS = [
+  { key: 'shellborn', name: 'Shellborn', symbol: '🐚', minXP: 0 },
+  { key: 'wave-seeker', name: 'Wave Seeker', symbol: '🌊', minXP: 100 },
+  { key: 'tide-whisperer', name: 'Tide Whisperer', symbol: '🌀', minXP: 400 },
+  { key: 'current-binder', name: 'Current Binder', symbol: '🪙', minXP: 1000 },
+  { key: 'pearl-bearer', name: 'Pearl Bearer', symbol: '🫧', minXP: 2000 },
+  { key: 'isle-champion', name: 'Isle Champion', symbol: '🏝️', minXP: 3500 },
+  { key: 'cowrie-ascendant', name: 'Cowrie Ascendant', symbol: '👑', minXP: 6000 },
+];
+
+function calculateProgression(rawXP = 0) {
+  const totalXP = Math.max(0, Number(rawXP) || 0);
+  let levelIndex = LEVELS.length - 1;
+  for (let i = 0; i < LEVELS.length; i += 1) {
+    const nextLevel = LEVELS[i + 1];
+    if (!nextLevel || totalXP < nextLevel.minXP) {
+      levelIndex = i;
+      break;
+    }
+  }
+
+  const level = LEVELS[levelIndex];
+  const nextLevel = LEVELS[levelIndex + 1] || null;
+  const xpIntoLevel = totalXP - level.minXP;
+  const xpToNext = nextLevel ? nextLevel.minXP - level.minXP : null;
+
+  const levelProgress = xpToNext ? clamp01(xpIntoLevel / xpToNext) : 1;
+  const nextXP = xpToNext ?? Math.max(xpIntoLevel, 1);
+
+  return {
+    totalXP,
+    xp: xpIntoLevel,
+    nextXP,
+    levelProgress,
+    levelName: level.name,
+    level: level.name,
+    levelSymbol: level.symbol,
+    levelIndex,
+    levelTier: level.key,
+    nextLevelTotalXP: nextLevel ? nextLevel.minXP : null,
+  };
+}
+
+function applyProgression(user, totalXP) {
+  const progression = calculateProgression(totalXP);
+  const next = {
+    ...user,
+    totalXP: progression.totalXP,
+    xp: progression.xp,
+    nextXP: progression.nextXP,
+    level: progression.levelName,
+    levelName: progression.levelName,
+    levelSymbol: progression.levelSymbol,
+    levelProgress: progression.levelProgress,
+    levelTier: progression.levelTier,
+  };
+  if (user && user.tier != null) {
+    next.tier = user.tier;
+  }
+  return next;
+}
+
+function ensureProgression(user) {
+  const baseXP =
+    user?.totalXP ?? user?.total_xp ?? user?.xp ?? user?.progressXP ?? 0;
+  return applyProgression(user || {}, baseXP);
+}
+
+function grantXP(user, delta) {
+  const totalBefore =
+    user?.totalXP ?? user?.total_xp ?? user?.xp ?? user?.progressXP ?? 0;
+  const nextTotal = Math.max(0, Number(totalBefore) || 0) + (Number(delta) || 0);
+  return applyProgression(user || {}, nextTotal);
+}
+
+module.exports = {
+  LEVELS,
+  calculateProgression,
+  ensureProgression,
+  grantXP,
+};

--- a/src/pages/Isles.jsx
+++ b/src/pages/Isles.jsx
@@ -33,8 +33,9 @@ function normalizeUser(raw, prev = {}) {
     raw;
 
   const levelName = base.levelName ?? base.level ?? prev.levelName ?? "Shellborn";
-  const xp = Number(base.xp ?? base.totalXP ?? base.total_xp ?? prev.xp ?? 0);
-  const nextXP = Number(base.nextXP ?? base.next_level_xp ?? base.nextLevelXP ?? prev.nextXP ?? 100);
+  const totalXP = Number(base.totalXP ?? base.total_xp ?? prev.totalXP ?? base.xp ?? 0);
+  const xp = Number(base.xp ?? prev.xp ?? totalXP);
+  const nextXP = Number(base.nextXP ?? base.next_level_xp ?? base.nextLevelXP ?? prev.nextXP ?? 0);
 
   let levelProgress =
     typeof base.levelProgress === "number" ? base.levelProgress :
@@ -48,6 +49,8 @@ function normalizeUser(raw, prev = {}) {
     levelName,
     xp,
     nextXP,
+    totalXP,
+    levelTier: base.levelTier ?? prev.levelTier ?? null,
     levelProgress: clamp01(levelProgress),
   };
 }
@@ -196,8 +199,10 @@ function useProfile(address) {
     wallet: null,
     levelName: "Shellborn",
     xp: 0,
-    nextXP: 100,
+    nextXP: null,
+    totalXP: 0,
     levelProgress: 0,
+    levelTier: "shellborn",
   });
   const [loading, setLoading] = useState(true);
 
@@ -300,7 +305,9 @@ export default function Isles() {
         <div className="profile-chip">
           <div className="chip-left">
             <span className="chip-title">{profile.levelName}</span>
-            <span className="chip-sub">XP {profile.xp} / {profile.nextXP}</span>
+            <span className="chip-sub">
+              XP {profile.xp} / {profile.nextXP ?? "∞"}
+            </span>
           </div>
           <Ring percent={progressPct} label="Level progress" />
         </div>


### PR DESCRIPTION
## Summary
- add a shared progression helper to normalise XP, level names and thresholds on the backend
- expose the computed progression metadata from /api/users/me and a new /api/profile fallback
- update the Isles page to rely on API-provided progression data instead of hard-coded values

## Testing
- npm test -- --watch=false *(fails: jsdom lacks HTMLMediaElement.load implementation)*

------
https://chatgpt.com/codex/tasks/task_e_68c915000164832b9009e0be15083e14