### PR TITLE
Add referral rewrites and backend root response

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,12 @@
 # Base URL of the 7GoldenCowries backend API
-REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
+# Leave blank to use same-origin /api routes (via Vercel rewrite)
+REACT_APP_API_URL=
+
+# For local development without the CRA proxy uncomment:
+# REACT_APP_API_URL=http://localhost:4000
+
+# Disable source map emission in production to avoid noisy warnings
+GENERATE_SOURCEMAP=false
 
 # Optional: override the TonConnect manifest location
 # REACT_APP_TONCONNECT_MANIFEST_URL=https://example.com/tonconnect-manifest.json

--- a/DEPLOY_NOTES.md
+++ b/DEPLOY_NOTES.md
@@ -4,6 +4,8 @@
 - `FRONTEND_URL` – allowed origin for CORS and referral redirects.
 - `DATABASE_URL` or `SQLITE_FILE` – path/connection string for SQLite database.
 - `SESSION_SECRET` – session signing secret.
+- `SUBSCRIPTION_BONUS_XP` – XP granted the first time `/api/v1/subscription/claim` succeeds.
+- `COOKIE_SECURE=true` when serving through HTTPS proxies so cookies include `SameSite=None; Secure`.
 - Social (optional): `TWITTER_CLIENT_ID`, `TELEGRAM_BOT_TOKEN`, `DISCORD_CLIENT_ID`, etc.
 
 ## One-time Database Checks

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -3,7 +3,18 @@
 ## Environment
 
 ```
-REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
+# Leave blank to rely on the Vercel -> Render rewrite
+REACT_APP_API_URL=
+GENERATE_SOURCEMAP=false
+```
+
+Backend (Render):
+
+```
+PORT=4000
+FRONTEND_URL=https://7goldencowries.com
+SUBSCRIPTION_BONUS_XP=120
+COOKIE_SECURE=true
 ```
 
 ## Vercel
@@ -11,6 +22,8 @@ REACT_APP_API_URL=https://sevengoldencowries-backend.onrender.com
 Add the domains:
 - 7goldencowries.com
 - www.7goldencowries.com
+
+Ensure the project uses the repo-root `vercel.json` so `/api/*` and `/ref/*` requests proxy to the Render backend and API responses include `Cache-Control: no-store` headers.
 
 ## Manual Test Steps
 

--- a/README.md
+++ b/README.md
@@ -5,18 +5,22 @@ Minimal React app for the 7GoldenCowries launch.
 ## Setup
 
 1. Install dependencies: `npm install`
-2. Copy `.env.example` to `.env` and set `REACT_APP_API_URL`.
-3. Start development server: `npm start`
+2. Copy `.env.example` to `.env`. Leave `REACT_APP_API_URL` blank to use the same origin `/api` routes through the provided Vercel rewrite, or set it to `http://localhost:4000` when running the backend separately.
+3. Ensure `GENERATE_SOURCEMAP=false` is present in `.env` for production builds to silence node_modules source-map warnings during deployment.
+4. Start the development server: `npm start`
+
+The CRA proxy is set to `http://localhost:4000` so local requests automatically forward to the backend during development. To target a remote backend from the browser (e.g. Render), set `REACT_APP_API_URL` to the absolute URL instead.
 
 TonConnect manifest is served from the same origin at `/tonconnect-manifest.json`. `www` permanently (308) redirects to the apex domain.
 
 ## API
 
-The frontend talks to the backend REST API:
+The frontend talks to the backend REST API. Key endpoints:
 
-- `GET /api/users/:wallet` – fetch profile (`xp`, `levelName`, `progress`)
-- `POST /api/quests/:id/claim` – claim quest; returns `{ alreadyClaimed: boolean }`
-- `GET /api/meta/progression` – XP progression metadata
+- `GET /api/users/me` – session profile (wallet, XP, socials)
+- `GET /api/v1/subscription/status` – subscription tier/level metadata
+- `POST /api/v1/subscription/claim` – claim the subscription XP bonus (idempotent)
+- `POST /api/quests/:id/claim` – claim quest XP; returns the normalized response payload
 
 ## Vercel
 
@@ -24,32 +28,32 @@ Deploy on Vercel with custom domains:
 - 7goldencowries.com
 - www.7goldencowries.com
 
+The default `vercel.json` rewrites `/api/*` and `/ref/*` to the Render backend so the frontend can run with a blank `REACT_APP_API_URL`.
+
 ## Manual Test Steps
 
 1. Set wallet to `UQTestWallet123` in the header input.
-2. Go to Quests and claim "Join our Telegram" → XP +40; re-claim → "Already claimed".
-3. Refresh page → XP persists and Profile widget progress reflects backend.
-4. Visit /leaderboard. Verify:
+2. Claim "Join our Telegram" → XP +40; re-claim → "Already claimed".
+3. Connect a social (Twitter/Discord/Telegram) and confirm the profile toast fires once, the confetti animation appears, and `/api/users/me` only fires a single request per focus event.
+4. Visit /subscription. Confirm tier data loads, then trigger **Claim Subscription XP Bonus**. The toast should show the `+N XP` delta, `/api/v1/subscription/claim` should return `xpDelta`, and the profile updates once via the `profile-updated` event.
+5. Visit /leaderboard. Verify:
    - Top 3 show as large cards with progress bars.
-   - Your wallet row is highlighted when localStorage.wallet is set.
-   - Progress bars reflect server levelProgress.
+   - Your wallet row is highlighted when `localStorage.wallet` is set.
+   - Progress bars reflect server `levelProgress`.
    - List re-sorts/refreshes within 60s and when wallet changes.
 
 ## How to test
 
-1. Connect a TON wallet via the header connect button.
-2. Visit `/token-sale`:
-   - Download the Wave 1 reminder `.ics` file using **Set Reminder** (powered by `downloadSaleReminder`).
-   - Enter a purchase amount and submit to confirm a POST to `/api/v1/token-sale/purchase`.
-3. Visit `/subscription`:
-   - Ensure your connected wallet and tier info load without refreshing.
-   - Start a tier checkout; verify the UI disables the selected tier until the `/api/v1/subscription/subscribe` response arrives.
-   - Append `?status=success` to the URL to see the callback banner and refreshed renewal date.
-
-## Scripts
-
 - `npm start` – run development server
-- `npm test` – run tests
-- `npm run build` – production build
+- `npm test` – run unit, integration, and API smoke tests (includes subscription flow coverage via supertest)
+- `npm run build` – production build (honors `GENERATE_SOURCEMAP=false`)
 
-See [LAUNCH.md](LAUNCH.md) for deployment notes and manual test steps.
+### Automated smoke checks
+
+`npm test` now exercises:
+
+1. API base URL handling and fetch de-duplication logic (prevents `/api/users/me` storms on focus).
+2. End-to-end subscription flow via supertest (wallet bind → status fetch → claim bonus → idempotent re-claim with consistent XP).
+
+These checks complement the manual steps above and catch regressions in the profile refresh and subscription reward flows.
+See [LAUNCH.md](LAUNCH.md) for deployment notes and extended manual scenarios.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+# Backend environment variables
+PORT=4000
+FRONTEND_URL=https://7goldencowries.com
+SUBSCRIPTION_BONUS_XP=120
+# Force secure cookies when running behind HTTPS proxies (Render)
+COOKIE_SECURE=true

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,62 @@ const {
 } = require('./src/lib/progression');
 
 const FRONTEND_URL = process.env.FRONTEND_URL || '';
+const SUBSCRIPTION_BONUS_XP = Math.max(
+  0,
+  Number(process.env.SUBSCRIPTION_BONUS_XP || 120)
+);
+
+function isSecureCookieEnv() {
+  if (process.env.COOKIE_SECURE === 'true') return true;
+  if (process.env.COOKIE_SECURE === 'false') return false;
+  return process.env.NODE_ENV === 'production';
+}
+
+function serializeCookie(name, value, options = {}) {
+  const parts = [];
+  const encodedValue = value == null ? '' : encodeURIComponent(value);
+  parts.push(`${name}=${encodedValue}`);
+
+  const {
+    maxAge,
+    path = '/',
+    httpOnly = true,
+    domain,
+    sameSite,
+    secure,
+    expires,
+  } = options;
+
+  if (path) parts.push(`Path=${path}`);
+  if (domain) parts.push(`Domain=${domain}`);
+  if (typeof maxAge === 'number') parts.push(`Max-Age=${maxAge}`);
+  if (expires instanceof Date) {
+    parts.push(`Expires=${expires.toUTCString()}`);
+  } else if (typeof expires === 'string') {
+    parts.push(`Expires=${expires}`);
+  }
+
+  if (httpOnly) parts.push('HttpOnly');
+
+  const secureFlag = secure ?? isSecureCookieEnv();
+  const sameSiteValue = sameSite ?? (secureFlag ? 'None' : 'Lax');
+  if (sameSiteValue) parts.push(`SameSite=${sameSiteValue}`);
+  if (secureFlag) parts.push('Secure');
+
+  return parts.join('; ');
+}
+
+function appendCookie(res, header) {
+  if (!header) return;
+  const prev = res.getHeader('Set-Cookie');
+  if (!prev) {
+    res.setHeader('Set-Cookie', header);
+  } else if (Array.isArray(prev)) {
+    res.setHeader('Set-Cookie', [...prev, header]);
+  } else {
+    res.setHeader('Set-Cookie', [prev, header]);
+  }
+}
 
 function defaultSocials() {
   return {
@@ -94,6 +150,28 @@ function getOrCreateUser(wallet) {
   return normalized;
 }
 
+function buildSubscriptionStatus(user, wallet) {
+  const profile = serializeUser(user || createBaseProfile(), {
+    wallet,
+    authed: Boolean(wallet),
+  });
+  const claimedAt = user?.subscriptionClaimedAt || null;
+  const lastClaimDelta = Number(user?.subscriptionLastDelta || 0);
+  return {
+    tier: profile.tier || 'Free',
+    levelName: profile.levelName || 'Shellborn',
+    levelSymbol: profile.levelSymbol || '🐚',
+    xp: profile.xp ?? 0,
+    xpIntoLevel: profile.xp ?? 0,
+    totalXP: profile.totalXP ?? 0,
+    nextXP: profile.nextXP ?? null,
+    wallet: profile.wallet ?? wallet ?? null,
+    canClaim: !claimedAt,
+    claimedAt,
+    lastClaimDelta,
+  };
+}
+
 // In‑memory stores for demo purposes
 const sessions = new Map();
 const users = new Map(); // wallet -> user profile
@@ -115,7 +193,7 @@ function getSession(req, res) {
   if (!sid || !sessions.has(sid)) {
     sid = crypto.randomUUID();
     sessions.set(sid, {});
-    res.setHeader('Set-Cookie', `sid=${sid}; Path=/; HttpOnly`);
+    appendCookie(res, serializeCookie('sid', sid, { httpOnly: true }));
   }
   return sessions.get(sid);
 }
@@ -124,16 +202,32 @@ const app = express();
 app.set('etag', false);
 
 // CORS configuration allowing production + local dev origins with credentials
-const allowedOrigins = [
-  FRONTEND_URL,
-  'https://7goldencowries.com',
-  'https://www.7goldencowries.com',
-  'http://localhost:3000',
-  'http://localhost:5173',
-].filter(Boolean);
+const allowedOrigins = new Set(
+  [
+    FRONTEND_URL,
+    'https://7goldencowries.com',
+    'https://www.7goldencowries.com',
+    'http://localhost:3000',
+    'http://localhost:5173',
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1:5173',
+  ]
+    .filter(Boolean)
+    .map((origin) => origin.replace(/\/+$/, ''))
+);
+
 app.use(
   cors({
-    origin: allowedOrigins,
+    origin(origin, callback) {
+      if (!origin) {
+        return callback(null, true);
+      }
+      const normalized = origin.replace(/\/+$/, '');
+      if (allowedOrigins.has(normalized)) {
+        return callback(null, normalized);
+      }
+      return callback(null, false);
+    },
     credentials: true,
   })
 );
@@ -180,9 +274,12 @@ app.get('/ref/:code', (req, res) => {
   if (!ownerWallet) {
     return res.status(404).send('Invalid referral code');
   }
-  res.setHeader(
-    'Set-Cookie',
-    `referral_code=${encodeURIComponent(code)}; Max-Age=2592000; Path=/; HttpOnly; SameSite=None; Secure`
+  appendCookie(
+    res,
+    serializeCookie('referral_code', code, {
+      maxAge: 2592000,
+      httpOnly: true,
+    })
   );
   const dest = FRONTEND_URL || 'https://7goldencowries.com';
   res.redirect(302, dest);
@@ -217,9 +314,12 @@ app.post('/api/session/bind-wallet', (req, res) => {
         users.set(refWallet, refUser);
       }
     }
-    res.setHeader(
-      'Set-Cookie',
-      'referral_code=; Max-Age=0; Path=/; HttpOnly; SameSite=None; Secure'
+    appendCookie(
+      res,
+      serializeCookie('referral_code', '', {
+        maxAge: 0,
+        httpOnly: true,
+      })
     );
   }
 
@@ -239,6 +339,64 @@ app.get('/api/users/me', (req, res) => {
   users.set(sess.wallet, user);
   sess.user = user;
   res.json(serializeUser(user, { wallet: sess.wallet, authed: true }));
+});
+
+app.get('/api/v1/subscription', (req, res) => {
+  res.redirect(301, '/api/v1/subscription/status');
+});
+
+app.get('/api/v1/subscription/status', (req, res) => {
+  const sess = getSession(req, res);
+  if (!sess.wallet) {
+    const status = buildSubscriptionStatus(null, null);
+    status.canClaim = false;
+    status.wallet = null;
+    status.claimedAt = null;
+    return res.json(status);
+  }
+  const user = getOrCreateUser(sess.wallet);
+  users.set(sess.wallet, user);
+  sess.user = user;
+  res.json(buildSubscriptionStatus(user, sess.wallet));
+});
+
+app.post('/api/v1/subscription/claim', (req, res) => {
+  const sess = getSession(req, res);
+  if (!sess.wallet) {
+    return res
+      .status(401)
+      .json({ error: 'unauthorized', message: 'Wallet session required' });
+  }
+
+  let user = getOrCreateUser(sess.wallet) || createBaseProfile({ wallet: sess.wallet });
+  let xpDelta = 0;
+  if (!user.subscriptionClaimedAt) {
+    const now = Date.now();
+    xpDelta = SUBSCRIPTION_BONUS_XP;
+    const history = Array.isArray(user.questHistory) ? [...user.questHistory] : [];
+    const updated = grantXP(user, xpDelta);
+    updated.subscriptionClaimedAt = now;
+    updated.subscriptionLastDelta = xpDelta;
+    history.push({
+      id: `subscription-${now}`,
+      title: 'Subscription bonus',
+      xp: xpDelta,
+      delta: xpDelta,
+      completed_at: new Date(now).toISOString(),
+    });
+    updated.questHistory = history;
+    user = updated;
+  } else {
+    user.subscriptionLastDelta = 0;
+  }
+
+  users.set(sess.wallet, user);
+  sess.user = user;
+
+  res.json({
+    xpDelta,
+    status: buildSubscriptionStatus(user, sess.wallet),
+  });
 });
 
 app.get('/api/profile', (req, res) => {
@@ -273,11 +431,19 @@ app.get('/api/referral/status', (req, res) => {
 // Placeholder: attach additional routes here
 // e.g., app.use('/api/quests', createRouter(db));
 
+app.get('/', (req, res) => {
+  res.json({
+    ok: true,
+    name: '7GoldenCowries API',
+    routes: ['/api/health', '/api/users/me', '/api/v1/subscription/status'],
+  });
+});
+
 module.exports = app;
 
 if (require.main === module) {
-  const port = process.env.PORT || 3000;
+  const port = process.env.PORT || 4000;
   app.listen(port, () => {
-    console.log(`Server listening on ${port}`);
+    console.log(`API listening on ${port}`);
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "supertest": "^6.3.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3004,6 +3007,19 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3037,6 +3053,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -5986,6 +6012,16 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -6092,6 +6128,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-js": {
@@ -6827,6 +6870,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -8156,6 +8210,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -8559,6 +8620,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -16011,6 +16088,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,15 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:4000",
   "eslintConfig": {
     "extends": [
       "react-app",
       "react-app/jest"
     ]
+  },
+  "devDependencies": {
+    "supertest": "^6.3.4"
   },
   "browserslist": {
     "production": [

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -15,3 +15,19 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
     dispatchEvent: () => false,
   });
 }
+
+if (typeof window !== 'undefined' && window.HTMLMediaElement) {
+  const proto = window.HTMLMediaElement.prototype;
+  Object.defineProperty(proto, 'load', {
+    configurable: true,
+    value: jest.fn(),
+  });
+  Object.defineProperty(proto, 'play', {
+    configurable: true,
+    value: jest.fn().mockResolvedValue(undefined),
+  });
+  Object.defineProperty(proto, 'pause', {
+    configurable: true,
+    value: jest.fn(),
+  });
+}

--- a/src/utils/api.test.js
+++ b/src/utils/api.test.js
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('api utilities', () => {
+  afterEach(() => {
+    delete global.fetch;
+    delete process.env.REACT_APP_API_URL;
+    jest.resetModules();
+  });
+
+  test('respects absolute REACT_APP_API_URL values', async () => {
+    jest.resetModules();
+    process.env.REACT_APP_API_URL = 'https://api.example.com/v1';
+    const responsePayload = { ok: true };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(responsePayload),
+      })
+    );
+    const { getJSON } = require('./api');
+    const data = await getJSON('/users/me');
+    expect(data).toEqual(responsePayload);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.example.com/v1/users/me',
+      expect.objectContaining({ credentials: 'include' })
+    );
+  });
+
+  test('dedupes concurrent requests without signals', async () => {
+    jest.resetModules();
+    process.env.REACT_APP_API_URL = '';
+    const resolvers = [];
+    global.fetch = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    const { getJSON } = require('./api');
+    const first = getJSON('/api/users/me');
+    const second = getJSON('/api/users/me');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    const firstResolver = resolvers.shift();
+    firstResolver({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ user: { wallet: 'EQTest' } }),
+    });
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toEqual(b);
+
+    const third = getJSON('/api/users/me');
+    const secondResolver = resolvers.shift();
+    secondResolver({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ user: { wallet: 'EQTest' } }),
+    });
+
+    await third;
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('disables dedupe when a signal is provided', async () => {
+    jest.resetModules();
+    process.env.REACT_APP_API_URL = '';
+    const fetchResponse = {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true }),
+    };
+    global.fetch = jest.fn(() => Promise.resolve(fetchResponse));
+    const { getJSON } = require('./api');
+
+    const controllerA = new AbortController();
+    const controllerB = new AbortController();
+
+    await Promise.all([
+      getJSON('/api/test', { signal: controllerA.signal }),
+      getJSON('/api/test', { signal: controllerB.signal }),
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
   "rewrites": [
-    { "source": "/auth/:match*", "destination": "https://sevengoldencowries-backend.onrender.com/auth/:match*" },
-    { "source": "/api/:match*",  "destination": "https://sevengoldencowries-backend.onrender.com/api/:match*" }
+    { "source": "/api/:path*", "destination": "https://sevengoldencowries-backend.onrender.com/api/:path*" },
+    { "source": "/ref/:path*", "destination": "https://sevengoldencowries-backend.onrender.com/ref/:path*" }
+  ],
+  "headers": [
+    { "source": "/api/(.*)", "headers": [{ "key": "Cache-Control", "value": "no-store" }] }
   ]
 }


### PR DESCRIPTION
## Summary
- accept absolute REACT_APP_API_URL values again, add in-flight dedupe to the shared fetch wrapper, and cover it with unit tests
- stabilize profile listeners/visibility refresh, tighten the subscription UI claim flow, and document the updated deployment/env guidance
- expose `/api/v1/subscription/status` and `/api/v1/subscription/claim` on the backend with stricter CORS/cookie handling plus supertest coverage and new .env examples
- add Vercel rewrites for `/api` and `/ref` traffic and serve a friendly JSON payload on the backend root to replace the default “Cannot GET /” page
- update the subscription claim UI to reuse the API response for local state, adjust docs to call out the `/ref/*` rewrite, and mock HTMLMediaElement methods so the Jest suite runs cleanly under jsdom

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9d6110264832b9a05fc079d432556