### PR TITLE
Add TonConnect paywall and payment verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,12 @@ REACT_APP_API_URL=
 # Disable source map emission in production to avoid noisy warnings
 GENERATE_SOURCEMAP=false
 
-# Optional: override the TonConnect manifest location
-# REACT_APP_TONCONNECT_MANIFEST_URL=https://example.com/tonconnect-manifest.json
+# TonConnect manifest + network (leave blank for same-origin manifest)
+REACT_APP_TONCONNECT_MANIFEST_URL=
+REACT_APP_TON_NETWORK=mainnet
+
+# Optional: override the TON receive address used for paywall payments
+# REACT_APP_TON_RECEIVE_ADDRESS=EQxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Twitter/X quest verification targets
 # (used by backend, included here for reference)

--- a/DEPLOY_NOTES.md
+++ b/DEPLOY_NOTES.md
@@ -6,6 +6,11 @@
 - `SESSION_SECRET` – session signing secret.
 - `SUBSCRIPTION_BONUS_XP` – XP granted the first time `/api/v1/subscription/claim` succeeds.
 - `COOKIE_SECURE=true` when serving through HTTPS proxies so cookies include `SameSite=None; Secure`.
+- `TON_NETWORK` – `mainnet` or `testnet` for TonCenter requests.
+- `TON_RECEIVE_ADDRESS` – wallet that collects subscription payments.
+- `TON_VERIFIER=toncenter` – current verification backend.
+- `TON_MIN_AMOUNT_NANO` – minimum accepted payment in nanoton (e.g. `500000000` for 0.5 TON).
+- `TONCENTER_API_KEY` – TonCenter API key used during verification.
 - Social (optional): `TWITTER_CLIENT_ID`, `TELEGRAM_BOT_TOKEN`, `DISCORD_CLIENT_ID`, etc.
 
 ## One-time Database Checks

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -1,32 +1,41 @@
 # Launch Notes
 
-## Environment
+## Frontend (Vercel env vars)
 
 ```
-# Leave blank to rely on the Vercel -> Render rewrite
 REACT_APP_API_URL=
 GENERATE_SOURCEMAP=false
+REACT_APP_TONCONNECT_MANIFEST_URL=
+REACT_APP_TON_NETWORK=mainnet
+# optional override when testing locally:
+# REACT_APP_TON_RECEIVE_ADDRESS=EQxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-Backend (Render):
+## Backend (Render env vars)
 
 ```
 PORT=4000
 FRONTEND_URL=https://7goldencowries.com
+SESSION_SECRET=super-secret
+SQLITE_FILE=/data/db.sqlite   # or DATABASE_URL
 SUBSCRIPTION_BONUS_XP=120
 COOKIE_SECURE=true
+TON_NETWORK=mainnet
+TON_RECEIVE_ADDRESS=EQxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TON_VERIFIER=toncenter
+TON_MIN_AMOUNT_NANO=500000000   # 0.5 TON (adjust as needed)
+TONCENTER_API_KEY=your-key
 ```
 
-## Vercel
+## Vercel configuration
 
-Add the domains:
-- 7goldencowries.com
-- www.7goldencowries.com
+- Add the domains `7goldencowries.com` and `www.7goldencowries.com`.
+- Ensure the project uses the repo-root `vercel.json`. Rewrites proxy `/api/*` and `/ref/*` to the Render backend and disable caching for API responses.
 
-Ensure the project uses the repo-root `vercel.json` so `/api/*` and `/ref/*` requests proxy to the Render backend and API responses include `Cache-Control: no-store` headers.
+## Manual smoke
 
-## Manual Test Steps
-
-1. Set wallet to `UQTestWallet123` in the header input.
-2. Claim "Join our Telegram" → XP +40, then re-claim → Already claimed.
-3. Refresh page → XP persists and Profile widget progress reflects backend.
+1. Connect a TON wallet and confirm only one `/api/users/me` fires on focus thanks to the debounced listener.
+2. Visit `/subscription` with an unpaid wallet. The paywall button should render. Complete a TonConnect payment, see the “Payment verified 🎉” toast, and confirm `/api/v1/payments/status` now returns `paid: true`.
+3. Claim the **Subscription XP Bonus** once to receive `+N XP`, then try again to confirm the backend returns `0` and the UI stays disabled.
+4. Link a social account from `/profile` and confirm a single toast/confetti burst plus one profile refresh.
+5. Run `npm run build` before deploying to verify `GENERATE_SOURCEMAP=false` and no CORS warnings.

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,12 +7,54 @@ const {
   ensureProgression,
   grantXP,
 } = require('./src/lib/progression');
+const { verifyTonPayment } = require('./src/lib/ton');
 
 const FRONTEND_URL = process.env.FRONTEND_URL || '';
 const SUBSCRIPTION_BONUS_XP = Math.max(
   0,
   Number(process.env.SUBSCRIPTION_BONUS_XP || 120)
 );
+
+function parseTonToNano(value) {
+  if (value == null) return 0n;
+  const raw = String(value).trim();
+  if (!raw) return 0n;
+  const sanitized = raw.replace(/[^0-9.]/g, '');
+  if (!sanitized) return 0n;
+  const [whole, fractional = ''] = sanitized.split('.');
+  let total = 0n;
+  if (whole) {
+    try {
+      total += BigInt(whole) * 1000000000n;
+    } catch (err) {
+      return 0n;
+    }
+  }
+  if (fractional) {
+    const frac = fractional.slice(0, 9).padEnd(9, '0');
+    try {
+      total += BigInt(frac);
+    } catch (err) {
+      return total;
+    }
+  }
+  return total;
+}
+
+const TON_RECEIVE_ADDRESS = (process.env.TON_RECEIVE_ADDRESS || '').trim();
+const TON_MIN_PAYMENT_NANO = (() => {
+  if (process.env.TON_MIN_AMOUNT_NANO) {
+    try {
+      return BigInt(process.env.TON_MIN_AMOUNT_NANO);
+    } catch (err) {
+      return 0n;
+    }
+  }
+  if (process.env.TON_MIN_TON) {
+    return parseTonToNano(process.env.TON_MIN_TON);
+  }
+  return 0n;
+})();
 
 function isSecureCookieEnv() {
   if (process.env.COOKIE_SECURE === 'true') return true;
@@ -83,6 +125,8 @@ function createBaseProfile(overrides = {}) {
     referralCount: 0,
     questHistory: [],
     authed: false,
+    paid: false,
+    lastPaymentAt: null,
     ...overrides,
   };
   return ensureProgression(profile);
@@ -133,6 +177,8 @@ function serializeUser(user, { wallet, authed } = {}) {
   } else {
     payload.authed = Boolean(payload.wallet);
   }
+  payload.paid = Boolean(payload.paid);
+  payload.lastPaymentAt = payload.lastPaymentAt ?? null;
   return payload;
 }
 
@@ -144,6 +190,12 @@ function getOrCreateUser(wallet) {
   }
   if (!user.socials) {
     user.socials = defaultSocials();
+  }
+  if (user.paid == null) {
+    user.paid = false;
+  }
+  if (user.lastPaymentAt == null) {
+    user.lastPaymentAt = null;
   }
   const normalized = ensureProgression(user);
   users.set(wallet, normalized);
@@ -157,6 +209,8 @@ function buildSubscriptionStatus(user, wallet) {
   });
   const claimedAt = user?.subscriptionClaimedAt || null;
   const lastClaimDelta = Number(user?.subscriptionLastDelta || 0);
+  const paid = Boolean(user?.paid);
+  const lastPaymentAt = user?.lastPaymentAt || null;
   return {
     tier: profile.tier || 'Free',
     levelName: profile.levelName || 'Shellborn',
@@ -166,7 +220,9 @@ function buildSubscriptionStatus(user, wallet) {
     totalXP: profile.totalXP ?? 0,
     nextXP: profile.nextXP ?? null,
     wallet: profile.wallet ?? wallet ?? null,
-    canClaim: !claimedAt,
+    paid,
+    lastPaymentAt,
+    canClaim: paid && !claimedAt,
     claimedAt,
     lastClaimDelta,
   };
@@ -236,6 +292,10 @@ app.use(express.json());
 app.use('/api', (req, res, next) => {
   res.set('Cache-Control', 'no-store');
   next();
+});
+
+app.get('/healthz', (req, res) => {
+  res.json({ ok: true, uptime: process.uptime(), timestamp: Date.now() });
 });
 
 app.get('/api/health', (req, res) => {
@@ -341,6 +401,73 @@ app.get('/api/users/me', (req, res) => {
   res.json(serializeUser(user, { wallet: sess.wallet, authed: true }));
 });
 
+app.get('/api/v1/payments/status', (req, res) => {
+  const sess = getSession(req, res);
+  if (!sess.wallet) {
+    return res.json({ paid: false, lastPaymentAt: null });
+  }
+  const user = getOrCreateUser(sess.wallet);
+  users.set(sess.wallet, user);
+  sess.user = user;
+  res.json({
+    paid: Boolean(user.paid),
+    lastPaymentAt: user.lastPaymentAt || null,
+  });
+});
+
+app.post('/api/v1/payments/verify', async (req, res) => {
+  const sess = getSession(req, res);
+  if (!sess.wallet) {
+    return res
+      .status(401)
+      .json({ verified: false, error: 'unauthorized', message: 'Wallet session required' });
+  }
+  if (!TON_RECEIVE_ADDRESS) {
+    return res.status(500).json({
+      verified: false,
+      error: 'not-configured',
+      message: 'TON_RECEIVE_ADDRESS not configured',
+    });
+  }
+
+  const body = req.body || {};
+  const txHash = typeof body.txHash === 'string' ? body.txHash.trim() : '';
+  const comment = typeof body.comment === 'string' ? body.comment.trim() : '';
+  if (!txHash) {
+    return res.status(400).json({ verified: false, error: 'txhash-required' });
+  }
+
+  try {
+    const verification = await verifyTonPayment({
+      txHash,
+      to: TON_RECEIVE_ADDRESS,
+      minAmount: TON_MIN_PAYMENT_NANO,
+      comment: comment || '7GC-SUB',
+    });
+    if (!verification?.verified) {
+      return res.status(422).json({ verified: false, detail: verification || null });
+    }
+
+    let user = getOrCreateUser(sess.wallet) || createBaseProfile({ wallet: sess.wallet });
+    user.paid = true;
+    user.lastPaymentAt = Date.now();
+    users.set(sess.wallet, user);
+    sess.user = user;
+
+    res.json({
+      verified: true,
+      paid: true,
+      lastPaymentAt: user.lastPaymentAt,
+    });
+  } catch (err) {
+    console.error('TON verification failed', err);
+    res.status(400).json({
+      verified: false,
+      error: err?.message || 'verification-failed',
+    });
+  }
+});
+
 app.get('/api/v1/subscription', (req, res) => {
   res.redirect(301, '/api/v1/subscription/status');
 });
@@ -352,6 +479,8 @@ app.get('/api/v1/subscription/status', (req, res) => {
     status.canClaim = false;
     status.wallet = null;
     status.claimedAt = null;
+    status.paid = false;
+    status.lastPaymentAt = null;
     return res.json(status);
   }
   const user = getOrCreateUser(sess.wallet);
@@ -369,6 +498,11 @@ app.post('/api/v1/subscription/claim', (req, res) => {
   }
 
   let user = getOrCreateUser(sess.wallet) || createBaseProfile({ wallet: sess.wallet });
+  if (!user.paid) {
+    return res
+      .status(402)
+      .json({ error: 'payment-required', message: 'Active subscription required' });
+  }
   let xpDelta = 0;
   if (!user.subscriptionClaimedAt) {
     const now = Date.now();
@@ -435,7 +569,13 @@ app.get('/', (req, res) => {
   res.json({
     ok: true,
     name: '7GoldenCowries API',
-    routes: ['/api/health', '/api/users/me', '/api/v1/subscription/status'],
+    routes: [
+      '/healthz',
+      '/api/health',
+      '/api/users/me',
+      '/api/v1/payments/status',
+      '/api/v1/subscription/status',
+    ],
   });
 });
 

--- a/backend/src/lib/ton.js
+++ b/backend/src/lib/ton.js
@@ -14,6 +14,17 @@ function normalizeAddress(value) {
   return String(value).trim();
 }
 
+function resolveSender(tx) {
+  const inMsg = tx?.in_msg || tx?.inMessage || tx || {};
+  const source =
+    inMsg.source?.address ||
+    inMsg.source ||
+    tx?.source?.address ||
+    tx?.source ||
+    null;
+  return normalizeAddress(source);
+}
+
 function decodeComment(message) {
   if (!message) return "";
   if (typeof message.comment === "string" && message.comment) {
@@ -158,6 +169,7 @@ async function verifyTonPayment({ txHash, to, minAmount = 0, comment }) {
     verified: true,
     amount: amount.toString(),
     to: expectedTo,
+    from: resolveSender(match) || null,
     comment: memo,
   };
 }

--- a/backend/src/lib/ton.js
+++ b/backend/src/lib/ton.js
@@ -1,0 +1,167 @@
+const DEFAULT_LIMIT = 20;
+
+function toBigInt(value) {
+  if (value == null) return 0n;
+  try {
+    return BigInt(String(value));
+  } catch (err) {
+    return 0n;
+  }
+}
+
+function normalizeAddress(value) {
+  if (!value) return "";
+  return String(value).trim();
+}
+
+function decodeComment(message) {
+  if (!message) return "";
+  if (typeof message.comment === "string" && message.comment) {
+    return message.comment;
+  }
+  const data = message.msg_data || message.body || {};
+  if (typeof data.text === "string" && data.text) {
+    return data.text;
+  }
+  const body = data.body || message.body;
+  if (typeof body === "string" && body) {
+    try {
+      const buf = Buffer.from(body, "base64");
+      const text = buf.toString("utf8").replace(/\0+$/g, "");
+      if (text) return text;
+    } catch (err) {
+      /* ignore */
+    }
+  }
+  return "";
+}
+
+async function fetchToncenterTransactions(address, limit = DEFAULT_LIMIT) {
+  const network = (process.env.TON_NETWORK || "mainnet").toLowerCase();
+  const base = network === "testnet"
+    ? "https://testnet.toncenter.com/api/v2"
+    : "https://toncenter.com/api/v2";
+  const apiKey = process.env.TONCENTER_API_KEY || "";
+  const params = new URLSearchParams({
+    address: normalizeAddress(address),
+    limit: String(limit),
+  });
+  const headers = { 'Content-Type': 'application/json' };
+  if (apiKey) headers['X-API-Key'] = apiKey;
+  const res = await fetch(`${base}/getTransactions?${params.toString()}`, {
+    headers,
+  });
+  if (!res.ok) {
+    throw new Error(`toncenter responded with ${res.status}`);
+  }
+  const data = await res.json();
+  const items = data?.result || data?.transactions || [];
+  return Array.isArray(items) ? items : [];
+}
+
+function collectHashes(tx) {
+  const hashes = [];
+  if (!tx || typeof tx !== "object") return hashes;
+  const candidates = [
+    tx.hash,
+    tx.transaction_id?.hash,
+    tx.transaction_id?.lt,
+    tx.in_msg?.hash,
+    tx.in_msg?.msg_id,
+  ];
+  candidates.forEach((value) => {
+    if (value) hashes.push(String(value).toLowerCase());
+  });
+  return hashes;
+}
+
+function resolveDestination(tx) {
+  const inMsg = tx?.in_msg || tx?.inMessage || tx || {};
+  const dest =
+    inMsg.destination?.address ||
+    inMsg.destination ||
+    tx?.account_addr ||
+    tx?.address ||
+    null;
+  return normalizeAddress(dest);
+}
+
+function resolveAmount(tx) {
+  const inMsg = tx?.in_msg || tx?.inMessage || tx || {};
+  const values = [
+    inMsg.value,
+    inMsg.amount,
+    tx?.in_msg_value,
+    tx?.value,
+  ];
+  for (const value of values) {
+    if (value != null) {
+      return toBigInt(value);
+    }
+  }
+  return 0n;
+}
+
+async function verifyTonPayment({ txHash, to, minAmount = 0, comment }) {
+  if (!txHash) throw new Error("txHash is required");
+  if (!to) throw new Error("destination address is required");
+  const provider = (process.env.TON_VERIFIER || "toncenter").toLowerCase();
+  if (provider !== "toncenter") {
+    throw new Error(`Unsupported TON verifier: ${provider}`);
+  }
+  const targetHash = String(txHash).toLowerCase();
+  const expectedTo = normalizeAddress(to);
+  const min = typeof minAmount === "string" || typeof minAmount === "number"
+    ? toBigInt(minAmount)
+    : (typeof minAmount === "bigint" ? minAmount : 0n);
+
+  const transactions = await fetchToncenterTransactions(expectedTo);
+  const match = transactions.find((tx) => collectHashes(tx).includes(targetHash));
+  if (!match) {
+    return { verified: false };
+  }
+
+  const destination = resolveDestination(match) || expectedTo;
+  if (normalizeAddress(destination) !== expectedTo) {
+    return {
+      verified: false,
+      amount: resolveAmount(match).toString(),
+      to: normalizeAddress(destination),
+      comment: decodeComment(match?.in_msg),
+    };
+  }
+
+  const amount = resolveAmount(match);
+  if (amount < min) {
+    return {
+      verified: false,
+      amount: amount.toString(),
+      to: expectedTo,
+      comment: decodeComment(match?.in_msg),
+    };
+  }
+
+  const memo = decodeComment(match?.in_msg);
+  if (comment && typeof comment === "string") {
+    const needle = comment.includes("7GC-SUB") ? "7GC-SUB" : comment;
+    if (!memo || !memo.includes(needle)) {
+      return {
+        verified: false,
+        amount: amount.toString(),
+        to: expectedTo,
+        comment: memo,
+      };
+    }
+  }
+
+  return {
+    verified: true,
+    amount: amount.toString(),
+    to: expectedTo,
+    comment: memo,
+  };
+}
+
+module.exports = {
+  verifyTonPayment,
+};

--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,7 +1,5 @@
 {
   "url": "https://7goldencowries.com",
-  "name": "7 Golden Cowries",
-  "iconUrl": "https://7goldencowries.com/icon-512.png",
-  "termsOfUseUrl": "https://7goldencowries.com/terms",
-  "privacyPolicyUrl": "https://7goldencowries.com/privacy"
+  "name": "7GoldenCowries",
+  "iconUrl": "https://7goldencowries.com/icon.png"
 }

--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe("api utils", () => {
+  const originalEnv = process.env.REACT_APP_API_URL;
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    jest.resetModules();
+    process.env.REACT_APP_API_URL = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  test("normalizes absolute API base URL", async () => {
+    process.env.REACT_APP_API_URL = "https://example.com///";
+    jest.resetModules();
+    const { API_BASE } = require("../utils/api");
+    expect(API_BASE).toBe("https://example.com");
+  });
+
+  test("treats blank API base as same-origin", async () => {
+    process.env.REACT_APP_API_URL = "  ";
+    jest.resetModules();
+    const { API_BASE } = require("../utils/api");
+    expect(API_BASE).toBe("");
+  });
+
+  test("de-dupes concurrent GET requests", async () => {
+    const response = { ok: true, status: 200, json: jest.fn(() => Promise.resolve({ ok: true })) };
+    const fetchMock = jest.fn(() => Promise.resolve(response));
+    global.fetch = fetchMock;
+    process.env.REACT_APP_API_URL = "https://api.example";
+    jest.resetModules();
+    const { getJSON } = require("../utils/api");
+    const [a, b] = await Promise.all([getJSON("/foo"), getJSON("/foo")]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(a).toEqual({ ok: true });
+    expect(b).toEqual({ ok: true });
+    await getJSON("/foo");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("de-dupes concurrent POST requests with identical bodies", async () => {
+    const response = { ok: true, status: 200, json: jest.fn(() => Promise.resolve({ ok: true })) };
+    const fetchMock = jest.fn(() => Promise.resolve(response));
+    global.fetch = fetchMock;
+    process.env.REACT_APP_API_URL = "https://api.example";
+    jest.resetModules();
+    const { postJSON } = require("../utils/api");
+    const payload = { hello: "world" };
+    const [first, second] = await Promise.all([
+      postJSON("/submit", payload),
+      postJSON("/submit", payload),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ ok: true });
+    expect(second).toEqual({ ok: true });
+  });
+});

--- a/src/__tests__/paywall.test.js
+++ b/src/__tests__/paywall.test.js
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+process.env.REACT_APP_TON_RECEIVE_ADDRESS = "EQTestReceiveAddress999";
+
+const mockSendTransaction = jest.fn();
+let mockWalletState = { account: { address: "EQTestWallet0000" } };
+
+jest.mock("@tonconnect/ui-react", () => ({
+  TonConnectUIProvider: ({ children }) => <>{children}</>,
+  TonConnectButton: (props) => <button {...props}>TonConnect</button>,
+  useTonConnectUI: () => [{ sendTransaction: mockSendTransaction }],
+  useTonWallet: () => mockWalletState,
+  __setMockWallet(next) {
+    mockWalletState = next;
+  },
+}));
+
+jest.mock("../utils/api", () => ({
+  getJSON: jest.fn(),
+  postJSON: jest.fn(),
+}));
+
+const { getJSON, postJSON } = require("../utils/api");
+const PaymentGuard = require("../components/PaymentGuard").default;
+
+function advancePromises() {
+  return act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("Paywall integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const tonUi = require("@tonconnect/ui-react");
+    tonUi.__setMockWallet({ account: { address: "EQTestWallet0000" } });
+  });
+
+  afterAll(() => {
+    delete process.env.REACT_APP_TON_RECEIVE_ADDRESS;
+  });
+
+  test("successful TonConnect payment verifies and unlocks content", async () => {
+    getJSON.mockResolvedValueOnce({ paid: false }).mockResolvedValueOnce({ paid: true });
+    postJSON.mockResolvedValue({ verified: true });
+    mockSendTransaction.mockResolvedValue({ transaction: { hash: "hash123" } });
+
+    const dispatchSpy = jest.spyOn(window, "dispatchEvent");
+
+    render(
+      <PaymentGuard>
+        <div data-testid="paid">Premium content</div>
+      </PaymentGuard>
+    );
+
+    const button = await screen.findByRole("button", { name: /unlock with tonconnect/i });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    await waitFor(() => expect(postJSON).toHaveBeenCalledTimes(1));
+    const payload = postJSON.mock.calls[0][1];
+    expect(payload.to).toBe("EQTestReceiveAddress999");
+    expect(payload.txHash).toBe("hash123");
+    expect(payload.comment).toMatch(/^7GC-SUB:/);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    await advancePromises();
+    expect(await screen.findByTestId("paid")).toBeInTheDocument();
+    expect(getJSON).toHaveBeenCalledTimes(2);
+    dispatchSpy.mockRestore();
+  });
+
+  test("TonConnect cancellation surfaces a single toast", async () => {
+    getJSON.mockResolvedValue({ paid: false });
+    postJSON.mockResolvedValue({ verified: false });
+    mockSendTransaction.mockRejectedValue({ code: "USER_REJECTS_ERROR" });
+
+    render(
+      <PaymentGuard>
+        <div data-testid="paid">Premium content</div>
+      </PaymentGuard>
+    );
+
+    const button = await screen.findByRole("button", { name: /unlock with tonconnect/i });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    await waitFor(() => expect(screen.getByText(/payment cancelled/i)).toBeInTheDocument());
+    expect(postJSON).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/PaymentGuard.jsx
+++ b/src/components/PaymentGuard.jsx
@@ -1,0 +1,70 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import PaywallButton from "./PaywallButton";
+import { getJSON } from "../utils/api";
+
+export default function PaymentGuard({ children, loadingFallback = null }) {
+  const [status, setStatus] = useState({ paid: null });
+  const [error, setError] = useState("");
+  const inflightRef = useRef(null);
+  const mountedRef = useRef(true);
+
+  const fetchStatus = useCallback(async () => {
+    if (inflightRef.current) {
+      return inflightRef.current;
+    }
+    const pending = getJSON("/api/v1/payments/status", { dedupe: true })
+      .then((res) => {
+        if (!mountedRef.current) return res;
+        setStatus({ paid: Boolean(res?.paid), raw: res });
+        setError("");
+        return res;
+      })
+      .catch((err) => {
+        if (!mountedRef.current) return null;
+        setError(err?.message || "Unable to load payment status");
+        setStatus({ paid: false });
+        return null;
+      })
+      .finally(() => {
+        inflightRef.current = null;
+      });
+    inflightRef.current = pending;
+    return pending;
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    fetchStatus();
+    const rerun = () => {
+      fetchStatus();
+    };
+    window.addEventListener("profile-updated", rerun);
+    return () => {
+      mountedRef.current = false;
+      window.removeEventListener("profile-updated", rerun);
+    };
+  }, [fetchStatus]);
+
+  if (status.paid == null) {
+    return loadingFallback || <p>Checking subscription status…</p>;
+  }
+
+  if (status.paid) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      {error ? (
+        <p className="error" style={{ marginBottom: 12 }}>
+          {error}
+        </p>
+      ) : (
+        <p style={{ marginBottom: 12 }}>
+          Become a subscriber to unlock this reward.
+        </p>
+      )}
+      <PaywallButton onSuccess={fetchStatus} />
+    </>
+  );
+}

--- a/src/components/PaywallButton.jsx
+++ b/src/components/PaywallButton.jsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTonConnectUI, useTonWallet } from "@tonconnect/ui-react";
+import { beginCell, Cell, toNano } from "@ton/core";
+import Toast from "./Toast";
+import { postJSON } from "../utils/api";
+
+const PLACEHOLDER_ADDRESS = "EQC7GCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const PAYMENT_MINUTES = 10;
+
+function toHex(bytes) {
+  if (!bytes) return "";
+  if (typeof bytes.toString === "function") {
+    try {
+      const maybeHex = bytes.toString("hex");
+      if (maybeHex && maybeHex !== "[object Object]") {
+        return maybeHex;
+      }
+    } catch (_) {
+      /* ignore */
+    }
+  }
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function encodeComment(comment) {
+  try {
+    return beginCell()
+      .storeUint(0, 32)
+      .storeStringTail(comment)
+      .endCell()
+      .toBoc()
+      .toString("base64");
+  } catch (err) {
+    console.warn("[PaywallButton] failed to encode comment", err);
+    return "";
+  }
+}
+
+function computeHash(result) {
+  if (!result) return null;
+  const direct =
+    result.transaction?.hash ||
+    result.txid?.hash ||
+    result.hash ||
+    null;
+  if (direct) return String(direct);
+  if (result.boc) {
+    try {
+      const cell = Cell.fromBase64(result.boc);
+      return toHex(cell.hash());
+    } catch (err) {
+      console.warn("[PaywallButton] unable to derive hash from BOC", err);
+    }
+  }
+  return null;
+}
+
+function toNanoSafe(value) {
+  try {
+    return toNano(String(value || "0")).toString();
+  } catch (err) {
+    console.warn("[PaywallButton] unable to convert amount", err);
+    return "0";
+  }
+}
+
+export default function PaywallButton({ onSuccess }) {
+  const [tonConnectUI] = useTonConnectUI();
+  const tonWallet = useTonWallet();
+  const [toast, setToast] = useState("");
+  const [loading, setLoading] = useState(false);
+  const timeoutRef = useRef(null);
+
+  const receiveAddress = useMemo(() => {
+    const env = process.env.REACT_APP_TON_RECEIVE_ADDRESS || "";
+    return env.trim() || PLACEHOLDER_ADDRESS;
+  }, []);
+
+  const tonAmount = useMemo(() => {
+    if (typeof window !== "undefined" && window.__TON_PAYMENT_TON) {
+      return String(window.__TON_PAYMENT_TON);
+    }
+    return process.env.REACT_APP_TON_PAYMENT_TON || "0.5";
+  }, []);
+
+  const amountNano = useMemo(() => toNanoSafe(tonAmount), [tonAmount]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  const showToast = useCallback((message) => {
+    setToast(message);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    timeoutRef.current = window.setTimeout(() => {
+      setToast("");
+      timeoutRef.current = null;
+    }, 3200);
+  }, []);
+
+  const requestPayment = useCallback(async () => {
+    if (loading) return;
+    if (!tonConnectUI) {
+      showToast("TonConnect UI unavailable");
+      return;
+    }
+    if (!receiveAddress || receiveAddress === PLACEHOLDER_ADDRESS) {
+      showToast("Payment address not configured");
+      return;
+    }
+    setLoading(true);
+
+    const comment = `7GC-SUB:${Date.now()}`;
+    const payload = encodeComment(comment);
+    const validUntil = Math.floor(Date.now() / 1000) + PAYMENT_MINUTES * 60;
+
+    try {
+      const transactionRequest = {
+        validUntil,
+        messages: [
+          {
+            address: receiveAddress,
+            amount: amountNano,
+            payload,
+          },
+        ],
+      };
+
+      const result = await tonConnectUI.sendTransaction(transactionRequest);
+      const txHash = computeHash(result);
+      if (!txHash) {
+        throw new Error("Transaction hash unavailable");
+      }
+
+      const verifyResponse = await postJSON("/api/v1/payments/verify", {
+        txHash,
+        amount: amountNano,
+        to: receiveAddress,
+        comment,
+      });
+
+      if (!verifyResponse?.verified) {
+        throw new Error("Payment verification failed");
+      }
+
+      window.dispatchEvent(new Event("profile-updated"));
+      showToast("Payment verified 🎉");
+      onSuccess?.();
+    } catch (err) {
+      const rejected =
+        err?.code === "USER_REJECTS_ERROR" ||
+        err?.code === 4001 ||
+        (typeof err?.message === "string" &&
+          err.message.toLowerCase().includes("reject"));
+      if (rejected) {
+        showToast("Payment cancelled");
+      } else {
+        const message = err?.message || "Payment failed";
+        showToast(message.startsWith("Network error") ? message : `${message}`);
+      }
+      console.warn("[PaywallButton] payment failed", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [amountNano, loading, onSuccess, receiveAddress, showToast, tonConnectUI]);
+
+  const walletLabel = tonWallet?.account?.address
+    ? `${tonWallet.account.address.slice(0, 4)}…${tonWallet.account.address.slice(-4)}`
+    : null;
+
+  return (
+    <div className="paywall-card">
+      <p style={{ marginBottom: 12 }}>
+        Unlock premium quests by sending <strong>{tonAmount} TON</strong> to our secure vault.
+      </p>
+      {walletLabel ? (
+        <p className="muted" style={{ marginBottom: 12 }}>
+          Connected wallet: {walletLabel}
+        </p>
+      ) : null}
+      <button className="btn" onClick={requestPayment} disabled={loading}>
+        {loading ? "Processing…" : `Unlock with TonConnect`}
+      </button>
+      <Toast message={toast} />
+    </div>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,14 @@ import { initHeroVideo } from './utils/video';
 import { setupWalletSync } from './utils/init';
 import { captureReferralFromQuery } from './utils/referral';
 
-const manifestUrl = `${window.location.origin}/tonconnect-manifest.json`;
+const manifestEnv = process.env.REACT_APP_TONCONNECT_MANIFEST_URL || "";
+const manifestUrl = manifestEnv.trim()
+  ? manifestEnv.trim()
+  : `${window.location.origin}/tonconnect-manifest.json`;
+
+if (typeof window !== "undefined") {
+  window.__TON_NETWORK = process.env.REACT_APP_TON_NETWORK || "mainnet";
+}
 
 captureReferralFromQuery();
 initTheme();

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "rewrites": [
     { "source": "/api/:path*", "destination": "https://sevengoldencowries-backend.onrender.com/api/:path*" },
-    { "source": "/auth/:path*", "destination": "https://sevengoldencowries-backend.onrender.com/auth/:path*" },
     { "source": "/ref/:path*", "destination": "https://sevengoldencowries-backend.onrender.com/ref/:path*" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- add a TonConnect-powered paywall with `PaymentGuard`/`PaywallButton` and hook it into the subscription page
- expose payment status/verification endpoints on the backend and guard subscription claims behind verified payments
- ship supporting docs, env updates, Vercel rewrites, and automated tests for the API layer and paywall UI

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ca2b9ff138832b8a6eb994f50bd187