### PR TITLE
Align Isle Champion XP threshold with canonical progression

### DIFF
--- a/backend/config/progression.js
+++ b/backend/config/progression.js
@@ -4,7 +4,7 @@ const LEVELS = [
   { key: 'tide-whisperer',   name: 'Tide Whisperer',   symbol: '🌀', min: 30_000 },
   { key: 'current-binder',   name: 'Current Binder',   symbol: '🪙', min: 60_000 },
   { key: 'pearl-bearer',     name: 'Pearl Bearer',     symbol: '🫧', min: 100_000 },
-  { key: 'isle-champion',    name: 'Isle Champion',    symbol: '🏝️', min: 160_000 },
+  { key: 'isle-champion',    name: 'Isle Champion',    symbol: '🏝️', min: 150_000 },
   { key: 'cowrie-ascendant', name: 'Cowrie Ascendant', symbol: '👑', min: 250_000 },
 ];
 

--- a/src/config/progression.js
+++ b/src/config/progression.js
@@ -4,7 +4,7 @@ export const LEVELS = [
   { key: 'tide-whisperer',   name: 'Tide Whisperer',   emoji: '🌀', min: 30000 },
   { key: 'current-binder',   name: 'Current Binder',   emoji: '🪙', min: 60000 },
   { key: 'pearl-bearer',     name: 'Pearl Bearer',     emoji: '🫧', min: 100000 },
-  { key: 'isle-champion',    name: 'Isle Champion',    emoji: '🏝️', min: 160000 },
+  { key: 'isle-champion',    name: 'Isle Champion',    emoji: '🏝️', min: 150000 },
   { key: 'cowrie-ascendant', name: 'Cowrie Ascendant', emoji: '👑', min: 250000 },
 ];
 


### PR DESCRIPTION
## Summary
- Update the shared progression constant to unlock Isle Champion at 150k XP per the canonical table
- Keep frontend and backend in sync so UI badges, island locks, and API progression report the same threshold

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cc714f1418832b8562c1baac3f66b2